### PR TITLE
Allow for missing parameter map

### DIFF
--- a/packages/c2pa/src/resolvers/editsAndActivity.ts
+++ b/packages/c2pa/src/resolvers/editsAndActivity.ts
@@ -91,7 +91,7 @@ async function getCategorizedActions(
       translateActionName(
         dictionary,
         // TODO: This should be resolved once we reconcile dictionary definitions
-        action.parameters.name ?? action.action,
+        action.parameters?.name ?? action.action,
         locale,
         iconVariant,
       ),


### PR DESCRIPTION
## Description

This fixes an issue where we get an error if an action assertion doesn't contain a parameter map. According to the [C2PA 1.0 spec](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_schema_and_example_6), `parameters` is optional and may not exist.

## Motivation and Context

We should be able to handle assets that conform to the spec without errors occurring.

## How Has This Been Tested?

Tested with Verify on sample images.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.