### PR TITLE
Update CI to run on pushes to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize]
 jobs:


### PR DESCRIPTION
## Changes in this pull request
Running CI on `main` broke last time we made a major revision to the CI file, this re-adds it.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
