### PR TITLE
added hidden box in indicator & trigger on element

### DIFF
--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -7,10 +7,10 @@
  * it.
  */
 
-import { LitElement, html, css } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { defaultStyles } from '../../styles';
 import '../../../assets/svg/color/info.svg';
+import { defaultStyles } from '../../styles';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -47,11 +47,24 @@ export class Indicator extends LitElement {
           --cai-icon-width: var(--cai-indicator-size, 24px);
           --cai-icon-height: var(--cai-indicator-size, 24px);
         }
+        .wrapper {
+          position: relative;
+        }
+        .hidden-layer {
+          position: absolute;
+          left: calc(var(--cai-popover-icon-size, 24px) * -1);
+          width: calc(var(--cai-popover-icon-width, 16px) + 10px);
+          height: calc(var(--cai-popover-icon-size, 24px) * 3);
+          top: calc(var(--cai-popover-icon-size, 24px) * -1);
+        }
       `,
     ];
   }
 
   render() {
-    return html`<cai-icon-info class="icon" />`;
+    return html`<div class="wrapper">
+      <div class="hidden-layer"></div>
+      <cai-icon-info class="icon" />
+    </div>`;
   }
 }

--- a/packages/c2pa-wc/src/components/Popover/Popover.ts
+++ b/packages/c2pa-wc/src/components/Popover/Popover.ts
@@ -95,6 +95,9 @@ export class Popover extends LitElement {
   @query('#content')
   contentElement: HTMLElement | undefined;
 
+  @query('#element')
+  hostElement: HTMLElement | undefined;
+
   @query('#trigger')
   triggerElement: HTMLElement | undefined;
 
@@ -211,15 +214,7 @@ export class Popover extends LitElement {
       const [show, hide] = trigger.split(':');
       this.triggerElement!.addEventListener(show, this._showTooltip.bind(this));
       if (this.interactive && hide === 'mouseleave') {
-        this.contentElement!.addEventListener(
-          hide,
-          this._hideTooltip.bind(this),
-        );
-      } else {
-        this.triggerElement!.addEventListener(
-          hide,
-          this._hideTooltip.bind(this),
-        );
+        this.hostElement!.addEventListener(hide, this._hideTooltip.bind(this));
       }
       return () => {
         this.triggerElement!.removeEventListener(show, this._showTooltip);


### PR DESCRIPTION
## Changes in this pull request
This PR makes sure that the L2 manifest summary closes when the tooltip is exited without needing to enter the manifest-summary

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
