### PR TITLE
added hidden box in indicator & trigger on element

### DIFF
--- a/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
+++ b/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "c2pa-wc",
-      "comment": "Makes sure the manifest summary close when the tooltip is exited",
+      "comment": "Makes sure the manifest summary closes when the tooltip is exited",
       "type": "patch"
     }
   ],

--- a/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
+++ b/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa-wc",
+      "comment": "This PR makes sure the manifest summary close when the tooltip is exited",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa-wc"
+}

--- a/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
+++ b/common/changes/c2pa-wc/CAI-3067-2_2023-01-19-17-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "c2pa-wc",
-      "comment": "This PR makes sure the manifest summary close when the tooltip is exited",
+      "comment": "Makes sure the manifest summary close when the tooltip is exited",
       "type": "patch"
     }
   ],

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -47,9 +47,7 @@ export class Indicator extends LitElement {
           --cai-icon-width: var(--cai-indicator-size, 24px);
           --cai-icon-height: var(--cai-indicator-size, 24px);
         }
-        .wrapper {
-          position: relative;
-        }
+
         .hidden-layer {
           position: absolute;
           left: calc(var(--cai-popover-icon-size, 24px) * -1);
@@ -62,9 +60,6 @@ export class Indicator extends LitElement {
   }
 
   render() {
-    return html`<div class="wrapper">
-      <div class="hidden-layer"></div>
-      <cai-icon-info class="icon" />
-    </div>`;
+    return html` <cai-icon-info class="icon" /> `;
   }
 }

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -47,14 +47,6 @@ export class Indicator extends LitElement {
           --cai-icon-width: var(--cai-indicator-size, 24px);
           --cai-icon-height: var(--cai-indicator-size, 24px);
         }
-
-        .hidden-layer {
-          position: absolute;
-          left: calc(var(--cai-popover-icon-size, 24px) * -1);
-          width: var(--cai-popover-icon-size, 24px);
-          height: calc(var(--cai-popover-icon-size, 24px) * 3);
-          top: calc(var(--cai-popover-icon-size, 24px) * -1);
-        }
       `,
     ];
   }

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -52,6 +52,6 @@ export class Indicator extends LitElement {
   }
 
   render() {
-    return html`<cai-icon-info class="icon" /> `;
+    return html`<cai-icon-info class="icon" />`;
   }
 }

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -52,6 +52,6 @@ export class Indicator extends LitElement {
   }
 
   render() {
-    return html` <cai-icon-info class="icon" /> `;
+    return html`<cai-icon-info class="icon" /> `;
   }
 }

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -7,10 +7,10 @@
  * it.
  */
 
-import { LitElement, html, css } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { defaultStyles } from '../../styles';
 import '../../../assets/svg/color/info.svg';
+import { defaultStyles } from '../../styles';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -47,11 +47,24 @@ export class Indicator extends LitElement {
           --cai-icon-width: var(--cai-indicator-size, 24px);
           --cai-icon-height: var(--cai-indicator-size, 24px);
         }
+        .wrapper {
+          position: relative;
+        }
+        .hidden-layer {
+          position: absolute;
+          left: calc(var(--cai-popover-icon-size, 24px) * -1);
+          width: calc(var(--cai-popover-icon-width, 16px) + 10px);
+          height: calc(var(--cai-popover-icon-size, 24px) * 3);
+          top: calc(var(--cai-popover-icon-size, 24px) * -1);
+        }
       `,
     ];
   }
 
   render() {
-    return html`<cai-icon-info class="icon" />`;
+    return html`<div class="wrapper">
+      <div class="hidden-layer"></div>
+      <cai-icon-info class="icon" />
+    </div>`;
   }
 }

--- a/packages/c2pa-wc/src/components/Indicator/Indicator.ts
+++ b/packages/c2pa-wc/src/components/Indicator/Indicator.ts
@@ -53,7 +53,7 @@ export class Indicator extends LitElement {
         .hidden-layer {
           position: absolute;
           left: calc(var(--cai-popover-icon-size, 24px) * -1);
-          width: calc(var(--cai-popover-icon-width, 16px) + 10px);
+          width: var(--cai-popover-icon-size, 24px);
           height: calc(var(--cai-popover-icon-size, 24px) * 3);
           top: calc(var(--cai-popover-icon-size, 24px) * -1);
         }

--- a/packages/c2pa-wc/src/components/Popover/Popover.ts
+++ b/packages/c2pa-wc/src/components/Popover/Popover.ts
@@ -215,7 +215,6 @@ export class Popover extends LitElement {
 
     this._eventCleanupFns = triggers.map((trigger) => {
       const [show, hide] = trigger.split(':');
-      console.log('show,hide', show, hide);
       this.triggerElement!.addEventListener(show, this._showTooltip.bind(this));
       if (this.interactive && hide === 'mouseleave') {
         this.hostElement!.addEventListener(hide, this._hideTooltip.bind(this));

--- a/packages/c2pa-wc/src/components/Popover/Popover.ts
+++ b/packages/c2pa-wc/src/components/Popover/Popover.ts
@@ -182,6 +182,13 @@ export class Popover extends LitElement {
           height: 8px;
           transform: rotate(45deg);
         }
+        .hidden-layer {
+          position: absolute;
+          left: calc(var(--cai-popover-icon-size, 24px) * -1);
+          width: var(--cai-popover-icon-size, 24px);
+          height: calc(var(--cai-popover-icon-size, 24px) * 3);
+          top: calc(var(--cai-popover-icon-size, 24px) * -1);
+        }
       `,
     ];
   }
@@ -208,9 +215,15 @@ export class Popover extends LitElement {
 
     this._eventCleanupFns = triggers.map((trigger) => {
       const [show, hide] = trigger.split(':');
+      console.log('show,hide', show, hide);
       this.triggerElement!.addEventListener(show, this._showTooltip.bind(this));
       if (this.interactive && hide === 'mouseleave') {
         this.hostElement!.addEventListener(hide, this._hideTooltip.bind(this));
+      } else {
+        this.triggerElement!.addEventListener(
+          hide,
+          this._hideTooltip.bind(this),
+        );
       }
       return () => {
         this.triggerElement!.removeEventListener(show, this._showTooltip);
@@ -345,6 +358,7 @@ export class Popover extends LitElement {
         ${this.arrow ? html`<div id="arrow"></div>` : null}
       </div>
       <div id="trigger">
+        <div class="hidden-layer"></div>
         <slot name="trigger"></slot>
       </div>
     </div>`;

--- a/packages/c2pa-wc/src/components/Popover/Popover.ts
+++ b/packages/c2pa-wc/src/components/Popover/Popover.ts
@@ -95,6 +95,9 @@ export class Popover extends LitElement {
   @query('#content')
   contentElement: HTMLElement | undefined;
 
+  @query('#element')
+  hostElement: HTMLElement | undefined;
+
   @query('#trigger')
   triggerElement: HTMLElement | undefined;
 
@@ -207,15 +210,7 @@ export class Popover extends LitElement {
       const [show, hide] = trigger.split(':');
       this.triggerElement!.addEventListener(show, this._showTooltip.bind(this));
       if (this.interactive && hide === 'mouseleave') {
-        this.contentElement!.addEventListener(
-          hide,
-          this._hideTooltip.bind(this),
-        );
-      } else {
-        this.triggerElement!.addEventListener(
-          hide,
-          this._hideTooltip.bind(this),
-        );
+        this.hostElement!.addEventListener(hide, this._hideTooltip.bind(this));
       }
       return () => {
         this.triggerElement!.removeEventListener(show, this._showTooltip);

--- a/packages/c2pa-wc/src/components/Tooltip/Tooltip.ts
+++ b/packages/c2pa-wc/src/components/Tooltip/Tooltip.ts
@@ -7,12 +7,12 @@
  * it.
  */
 
+import { autoPlacement } from '@floating-ui/dom';
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import '../../../assets/svg/monochrome/help.svg';
 import { defaultStyles } from '../../styles';
-import { autoPlacement } from '@floating-ui/dom';
 
 import '../Icon';
 import '../Popover';


### PR DESCRIPTION
## Changes in this pull request
This PR makes sure that the L2 manifest summary closes when the tooltip is exited without needing to enter the manifest-summary

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
