### PR TITLE
Update c2pa-rs to 0.16.1 and added fix for remote URLs

### DIFF
--- a/common/changes/@contentauth/toolkit/update-c2pa-rs-remote-err_2023-01-26-16-29.json
+++ b/common/changes/@contentauth/toolkit/update-c2pa-rs-remote-err_2023-01-26-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/toolkit",
+      "comment": "Update c2pa-rs to 0.16.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@contentauth/toolkit"
+}

--- a/common/changes/c2pa/update-c2pa-rs-remote-err_2023-01-26-16-29.json
+++ b/common/changes/c2pa/update-c2pa-rs-remote-err_2023-01-26-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "Add validation for remote manifests that are not properly-formed URLs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/packages/toolkit/Cargo.lock
+++ b/packages/toolkit/Cargo.lock
@@ -71,7 +71,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e7c3bae57b01ec5b1b028af1f77b7d41dd2bd97a41bab7968739b5329c0e39"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "smallvec",
 ]
 
@@ -179,10 +179,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "bytes"
-version = "0.5.6"
+name = "byteordered"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "bbf2cd9424f5ff404aba1959c835cbc448ee8b689b870a9981c76c0fd46280e6"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "bytes"
@@ -192,16 +195,17 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "c2pa"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5eadc06ea58cfa080c18314541bd6c2dfe2a6aa662fbe4270f3c25fe7e11e58"
+checksum = "d0cf6bca507b49e93db9d29a8e886d3c4db7c28ff46283ae6bbedfc8f24289d0"
 dependencies = [
  "atree",
  "base64",
  "bcder",
  "blake3",
  "byteorder",
- "bytes 1.2.1",
+ "byteordered",
+ "bytes",
  "chrono",
  "ciborium",
  "console_log",
@@ -217,7 +221,6 @@ dependencies = [
  "log",
  "multibase",
  "multihash",
- "nom",
  "png_pong",
  "quick-xml",
  "rand",
@@ -841,13 +844,13 @@ dependencies = [
 
 [[package]]
 name = "img-parts"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e210871d2017abd6d46ffc9f743747549cb54fdeef37fbcc829400f52794e4e5"
+checksum = "b19358258d99a5fc34466fed27a5318f92ae636c3e36165cf9b1e87b5b6701f0"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "crc32fast",
- "miniz_oxide 0.4.4",
+ "miniz_oxide 0.5.4",
 ]
 
 [[package]]
@@ -2028,7 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecce82ba1a532273edf6cd88d1efca9b3417fd24abe81baf143657909f7c12a8"
 dependencies = [
  "bcder",
- "bytes 1.2.1",
+ "bytes",
  "chrono",
  "hex",
  "pem",

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.9.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-c2pa = {version = "0.15.0", features=["serialize_thumbnails"]}
+c2pa = {version = "0.16.1", features=["serialize_thumbnails"]}
 console_error_panic_hook = "0.1.7"
 console_log = {version = "0.2", features = ["color"]}
 log = "0.4.14"

--- a/packages/toolkit/src/manifest_store.rs
+++ b/packages/toolkit/src/manifest_store.rs
@@ -8,12 +8,15 @@ use crate::error::{Error, Result};
 use c2pa::ManifestStore;
 
 pub async fn get_manifest_store_data(data: &[u8], mime_type: &str) -> Result<ManifestStore> {
-    ManifestStore::from_bytes_async(mime_type, data.to_owned(), true)
+    ManifestStore::from_bytes_async(mime_type, data, true)
         .await
         .map_err(Error::from)
 }
 
-pub async fn get_manifest_store_data_from_manifest_and_asset_bytes(manifest_bytes: &[u8], asset_bytes: &[u8]) -> Result<ManifestStore> {
+pub async fn get_manifest_store_data_from_manifest_and_asset_bytes(
+    manifest_bytes: &[u8],
+    asset_bytes: &[u8],
+) -> Result<ManifestStore> {
     ManifestStore::from_manifest_and_asset_bytes_async(manifest_bytes, asset_bytes)
         .await
         .map_err(Error::from)


### PR DESCRIPTION
## Changes in this pull request
Adds validation for remote manifests that are not properly-formed URLs. The test that triggered this had a JUMBF URL in the XMP `dcterms:provenance` tag, but no claim data. `c2patool` reported no claim data - this updates our code to do the same.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
