### PR TITLE
Export C2PA action categorization function to support #75

### DIFF
--- a/common/changes/c2pa/export-c2pa-categorized-actions_2023-02-07-20-37.json
+++ b/common/changes/c2pa/export-c2pa-categorized-actions_2023-02-07-20-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "Exported `getC2paCategorizedActions` function from `selectEditsAndActivity` selector file",
+      "type": "minor"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/packages/c2pa/index.ts
+++ b/packages/c2pa/index.ts
@@ -7,38 +7,37 @@
  * it.
  */
 
+export { AssertionAccessor, ExtendedAssertions } from './src/assertions';
 export {
+  C2pa,
+  C2paConfig,
+  C2paReadResult,
   createC2pa,
   generateVerifyUrl,
-  C2paReadResult,
-  C2paConfig,
-  C2pa,
 } from './src/c2pa';
 export {
+  createL2ManifestStore,
   DisposableL2ManifestStore,
+  ErrorStatus,
   L2ClaimGenerator,
   L2EditsAndActivity,
   L2Ingredient,
+  L2ManifestStore,
   L2Producer,
   L2Signature,
   L2SocialAccount,
-  ErrorStatus,
 } from './src/createL2ManifestStore';
-export { DownloaderOptions } from './src/lib/downloader';
-export { ManifestStore, ManifestMap } from './src/manifestStore';
-export { Manifest } from './src/manifest';
 export { Ingredient } from './src/ingredient';
-export { Source, C2paSourceType, SourceMetadata } from './src/source';
-export { AssertionAccessor, ExtendedAssertions } from './src/assertions';
-export { Thumbnail, DisposableBlobUrl, BlobUrlData } from './src/thumbnail';
+export { DownloaderOptions } from './src/lib/downloader';
+export { Manifest } from './src/manifest';
+export { ManifestMap, ManifestStore } from './src/manifestStore';
 export {
-  selectEditsAndActivity,
+  getC2paCategorizedActions,
   IconVariant,
+  selectEditsAndActivity,
   TranslatedDictionaryCategory,
 } from './src/selectors/selectEditsAndActivity';
 export { selectProducer } from './src/selectors/selectProducer';
 export { selectSocialAccounts } from './src/selectors/selectSocialAccounts';
-export {
-  createL2ManifestStore,
-  L2ManifestStore,
-} from './src/createL2ManifestStore';
+export { C2paSourceType, Source, SourceMetadata } from './src/source';
+export { BlobUrlData, DisposableBlobUrl, Thumbnail } from './src/thumbnail';

--- a/packages/c2pa/src/selectors/selectEditsAndActivity.ts
+++ b/packages/c2pa/src/selectors/selectEditsAndActivity.ts
@@ -115,7 +115,7 @@ function getTranslationsForLocale(locale: string = DEFAULT_LOCALE) {
  * @param manifest - Manifest to derive data from
  * @param locale - BCP-47 locale code (e.g. `en-US`, `fr-FR`) to request localized strings, if available
  * @param iconVariant - Requests icon variant (e.g. `light`, `dark`), if available
- * @returns
+ * @returns List of translated action categories
  */
 export async function selectEditsAndActivity(
   manifest: Manifest,
@@ -185,6 +185,16 @@ interface OverrideActionMap {
   actions: OverrideLocalizationMap[];
 }
 
+/**
+ * Gets a list of action categories, derived from the provided manifest's `c2pa.action` assertion.
+ * This will also handle translations by providing a locale. This works for standard C2PA action assertion
+ * data only.
+ *
+ * @param actionsAssertion - Action assertion data
+ * @param locale - BCP-47 locale code (e.g. `en-US`, `fr-FR`) to request localized strings, if available
+ * @param iconVariant - Requests icon variant (e.g. `light`, `dark`), if available
+ * @returns List of translated action categories
+ */
 export function getC2paCategorizedActions(
   actionsAssertion: C2paActionsAssertion,
   locale: string = DEFAULT_LOCALE,

--- a/packages/c2pa/src/selectors/selectEditsAndActivity.ts
+++ b/packages/c2pa/src/selectors/selectEditsAndActivity.ts
@@ -185,7 +185,7 @@ interface OverrideActionMap {
   actions: OverrideLocalizationMap[];
 }
 
-function getC2paCategorizedActions(
+export function getC2paCategorizedActions(
   actionsAssertion: C2paActionsAssertion,
   locale: string = DEFAULT_LOCALE,
 ): TranslatedDictionaryCategory[] {


### PR DESCRIPTION
## Changes in this pull request
Exported `getC2paCategorizedActions` function from `selectEditsAndActivity` selector file to support #75.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
