### PR TITLE
Fix JUMBF and thumbnail errors

### DIFF
--- a/common/autoinstallers/rush-prettier/pnpm-lock.yaml
+++ b/common/autoinstallers/rush-prettier/pnpm-lock.yaml
@@ -9,102 +9,70 @@ dependencies:
   pretty-quick: 3.1.3_prettier@2.6.2
 
 packages:
+
   /@types/minimatch/3.0.5:
-    resolution:
-      {
-        integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==,
-      }
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
     dev: false
 
   /ansi-styles/4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
     dev: false
 
   /array-differ/3.0.0:
-    resolution:
-      {
-        integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
+    engines: {node: '>=8'}
     dev: false
 
   /array-union/2.1.0:
-    resolution:
-      {
-        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
     dev: false
 
   /arrify/2.0.1:
-    resolution:
-      {
-        integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
     dev: false
 
   /balanced-match/1.0.2:
-    resolution:
-      {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-      }
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
   /brace-expansion/1.1.11:
-    resolution:
-      {
-        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
-      }
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: false
 
   /chalk/3.0.0:
-    resolution:
-      {
-        integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: false
 
   /color-convert/2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
-    engines: { node: '>=7.0.0' }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
     dev: false
 
   /color-name/1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: false
 
   /concat-map/0.0.1:
-    resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
   /cross-spawn/7.0.3:
-    resolution:
-      {
-        integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==,
-      }
-    engines: { node: '>= 8' }
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -112,20 +80,14 @@ packages:
     dev: false
 
   /end-of-stream/1.4.4:
-    resolution:
-      {
-        integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==,
-      }
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
     dev: false
 
   /execa/4.1.0:
-    resolution:
-      {
-        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
-      }
-    engines: { node: '>=10' }
+    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
+    engines: {node: '>=10'}
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 5.2.0
@@ -139,113 +101,74 @@ packages:
     dev: false
 
   /find-up/4.1.0:
-    resolution:
-      {
-        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
     dev: false
 
   /get-stream/5.2.0:
-    resolution:
-      {
-        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
     dev: false
 
   /has-flag/4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
     dev: false
 
   /human-signals/1.1.1:
-    resolution:
-      {
-        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
-      }
-    engines: { node: '>=8.12.0' }
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
     dev: false
 
   /ignore/5.2.0:
-    resolution:
-      {
-        integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==,
-      }
-    engines: { node: '>= 4' }
+    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+    engines: {node: '>= 4'}
     dev: false
 
   /is-stream/2.0.1:
-    resolution:
-      {
-        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
     dev: false
 
   /isexe/2.0.0:
-    resolution:
-      {
-        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-      }
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: false
 
   /locate-path/5.0.0:
-    resolution:
-      {
-        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
     dev: false
 
   /merge-stream/2.0.0:
-    resolution:
-      {
-        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
-      }
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: false
 
   /mimic-fn/2.1.0:
-    resolution:
-      {
-        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
-      }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
     dev: false
 
   /minimatch/3.1.2:
-    resolution:
-      {
-        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
-      }
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: false
 
   /mri/1.2.0:
-    resolution:
-      {
-        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-      }
-    engines: { node: '>=4' }
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
     dev: false
 
   /multimatch/4.0.0:
-    resolution:
-      {
-        integrity: sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==}
+    engines: {node: '>=8'}
     dependencies:
       '@types/minimatch': 3.0.5
       array-differ: 3.0.0
@@ -255,93 +178,63 @@ packages:
     dev: false
 
   /npm-run-path/4.0.1:
-    resolution:
-      {
-        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
     dev: false
 
   /once/1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /onetime/5.1.2:
-    resolution:
-      {
-        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
-      }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
     dev: false
 
   /p-limit/2.3.0:
-    resolution:
-      {
-        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
-      }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
     dev: false
 
   /p-locate/4.1.0:
-    resolution:
-      {
-        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
     dev: false
 
   /p-try/2.2.0:
-    resolution:
-      {
-        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
-      }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
     dev: false
 
   /path-exists/4.0.0:
-    resolution:
-      {
-        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
     dev: false
 
   /path-key/3.1.1:
-    resolution:
-      {
-        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
     dev: false
 
   /prettier/2.6.2:
-    resolution:
-      {
-        integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==,
-      }
-    engines: { node: '>=10.13.0' }
+    resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
     dev: false
 
   /pretty-quick/3.1.3_prettier@2.6.2:
-    resolution:
-      {
-        integrity: sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==,
-      }
-    engines: { node: '>=10.13' }
+    resolution: {integrity: sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==}
+    engines: {node: '>=10.13'}
     hasBin: true
     peerDependencies:
       prettier: '>=2.0.0'
@@ -356,69 +249,48 @@ packages:
     dev: false
 
   /pump/3.0.0:
-    resolution:
-      {
-        integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==,
-      }
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
     dev: false
 
   /shebang-command/2.0.0:
-    resolution:
-      {
-        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
     dev: false
 
   /shebang-regex/3.0.0:
-    resolution:
-      {
-        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
     dev: false
 
   /signal-exit/3.0.7:
-    resolution:
-      {
-        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
-      }
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: false
 
   /strip-final-newline/2.0.0:
-    resolution:
-      {
-        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
-      }
-    engines: { node: '>=6' }
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
     dev: false
 
   /supports-color/7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: '>=8' }
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
     dev: false
 
   /which/2.0.2:
-    resolution:
-      {
-        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-      }
-    engines: { node: '>= 8' }
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: false
 
   /wrappy/1.0.2:
-    resolution: { integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= }
+    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
     dev: false

--- a/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
+++ b/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/detector",
+      "comment": "Adds the new `--weak-refs` and `--reference-types` flags now available in [wasm-pack 0.11.0](https://github.com/rustwasm/wasm-pack/blob/mast",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@contentauth/detector"
+}

--- a/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
+++ b/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/detector",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@contentauth/detector"
+}

--- a/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-45.json
+++ b/common/changes/@contentauth/detector/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/detector",
+      "comment": "Remove dependency on [wee_alloc](https://github.com/rustwasm/wee_alloc) since it is unmaintained and has a reported memory leak",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@contentauth/detector"
+}

--- a/common/changes/@contentauth/react/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
+++ b/common/changes/@contentauth/react/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@contentauth/react"
+}

--- a/common/changes/@contentauth/react/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
+++ b/common/changes/@contentauth/react/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@contentauth/react"
+}

--- a/common/changes/@contentauth/toolkit/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
+++ b/common/changes/@contentauth/toolkit/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/toolkit",
+      "comment": "Adds the new `--weak-refs` flag now available in [wasm-pack 0.11.0](https://github.com/rustwasm/wasm-pack/blob/master/CHANGELOG.md#-fixes) for more reliable memory cleanup (`--reference-types` causes a memory access error in Safari, so that was not added)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@contentauth/toolkit"
+}

--- a/common/changes/@contentauth/toolkit/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
+++ b/common/changes/@contentauth/toolkit/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/toolkit",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@contentauth/toolkit"
+}

--- a/common/changes/c2pa-wc/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
+++ b/common/changes/c2pa-wc/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa-wc",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "c2pa-wc"
+}

--- a/common/changes/c2pa-wc/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
+++ b/common/changes/c2pa-wc/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa-wc",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "c2pa-wc"
+}

--- a/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
+++ b/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "Fixes error on `read` that would get triggered if an ingredient doesn't have a thumbnail",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
+++ b/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-45.json
+++ b/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "Allows assets that have invalid JUMBF box to have their sources passed through to the client during a `read` request instead instead of throwing an error so that the asset can still be displayed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-46.json
+++ b/common/changes/c2pa/dkozma-fix-jumbf-thumbnail-errors_2023-03-22-16-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "Fixes TypeScript errors by updating our `target` to `es2017` to use some newer (but widely supported) JavaScript APIs, as well as removing `process.env` in favor of a constant for the integrity logic",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
       '@rollup/plugin-commonjs': ~22.0.0
       '@rollup/plugin-json': ~4.1.0
       '@rollup/plugin-node-resolve': ^13.3.0
-      '@rollup/plugin-replace': ~4.0.0
+      '@rollup/plugin-replace': ~5.0.2
       '@rollup/plugin-strip': ~2.1.0
       '@rollup/plugin-typescript': ~8.3.2
       '@rollup/plugin-wasm': ~5.1.2
@@ -159,7 +159,7 @@ importers:
       '@rollup/plugin-commonjs': 22.0.1_rollup@2.70.2
       '@rollup/plugin-json': 4.1.0_rollup@2.70.2
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.70.2
-      '@rollup/plugin-replace': 4.0.0_rollup@2.70.2
+      '@rollup/plugin-replace': 5.0.2_rollup@2.70.2
       '@rollup/plugin-strip': 2.1.0_rollup@2.70.2
       '@rollup/plugin-typescript': 8.3.3_ebyyw52y5in2luxvejy6eu2iqq
       '@rollup/plugin-wasm': 5.1.2_rollup@2.70.2
@@ -198,7 +198,7 @@ importers:
       '@rollup/plugin-commonjs': ~22.0.0
       '@rollup/plugin-json': ~4.1.0
       '@rollup/plugin-node-resolve': ^13.3.0
-      '@rollup/plugin-replace': ~4.0.0
+      '@rollup/plugin-replace': ~5.0.2
       '@rollup/plugin-typescript': ~8.3.2
       '@rollup/pluginutils': ~4.2.1
       '@rushstack/eslint-config': ~2.6.0
@@ -276,7 +276,7 @@ importers:
       '@rollup/plugin-commonjs': 22.0.1_rollup@2.70.2
       '@rollup/plugin-json': 4.1.0_rollup@2.70.2
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.70.2
-      '@rollup/plugin-replace': 4.0.0_rollup@2.70.2
+      '@rollup/plugin-replace': 5.0.2_rollup@2.70.2
       '@rollup/plugin-typescript': 8.3.3_ebyyw52y5in2luxvejy6eu2iqq
       '@rollup/pluginutils': 4.2.1
       '@rushstack/eslint-config': 2.6.1_t725usgvqspm5woeqpaxbfp2qu
@@ -342,7 +342,7 @@ importers:
       '@rollup/plugin-alias': ~3.1.9
       '@rollup/plugin-commonjs': ~22.0.0
       '@rollup/plugin-node-resolve': ^13.3.0
-      '@rollup/plugin-replace': ~4.0.0
+      '@rollup/plugin-replace': ~5.0.2
       '@rollup/plugin-strip': ~2.1.0
       '@rollup/plugin-typescript': ~8.3.2
       '@rushstack/eslint-config': ~2.6.0
@@ -374,7 +374,7 @@ importers:
       '@rollup/plugin-alias': 3.1.9_rollup@2.70.2
       '@rollup/plugin-commonjs': 22.0.1_rollup@2.70.2
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.70.2
-      '@rollup/plugin-replace': 4.0.0_rollup@2.70.2
+      '@rollup/plugin-replace': 5.0.2_rollup@2.70.2
       '@rollup/plugin-strip': 2.1.0_rollup@2.70.2
       '@rollup/plugin-typescript': 8.3.3_ebyyw52y5in2luxvejy6eu2iqq
       '@rushstack/eslint-config': 2.6.1_t725usgvqspm5woeqpaxbfp2qu
@@ -399,7 +399,7 @@ importers:
   ../../packages/toolkit:
     specifiers:
       '@contentauth/testing': workspace:*
-      '@rollup/plugin-replace': ~4.0.0
+      '@rollup/plugin-replace': ~5.0.2
       '@types/jasmine': ~4.0.3
       '@web/dev-server-esbuild': ~0.3.0
       '@web/dev-server-rollup': ~0.3.17
@@ -422,7 +422,7 @@ importers:
       web-test-runner-jasmine: ~0.0.1
     devDependencies:
       '@contentauth/testing': link:../../tools/testing
-      '@rollup/plugin-replace': 4.0.0_rollup@2.70.2
+      '@rollup/plugin-replace': 5.0.2_rollup@2.70.2
       '@types/jasmine': 4.0.3
       '@web/dev-server-esbuild': 0.3.1
       '@web/dev-server-rollup': 0.3.18
@@ -3760,13 +3760,17 @@ packages:
       rollup: 2.70.2
     dev: true
 
-  /@rollup/plugin-replace/4.0.0_rollup@2.70.2:
-    resolution: {integrity: sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==}
+  /@rollup/plugin-replace/5.0.2_rollup@2.70.2:
+    resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.70.2
-      magic-string: 0.25.9
+      '@rollup/pluginutils': 5.0.2_rollup@2.70.2
+      magic-string: 0.27.0
       rollup: 2.70.2
     dev: true
 
@@ -3824,6 +3828,21 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@2.70.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 2.70.2
     dev: true
 
   /@rushstack/eslint-config/2.6.1_t725usgvqspm5woeqpaxbfp2qu:
@@ -6093,12 +6112,12 @@ packages:
     resolution: {integrity: sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==}
     dependencies:
       '@types/eslint': 8.4.3
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
 
   /@types/eslint/8.4.3:
     resolution: {integrity: sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==}
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
 
   /@types/estree/0.0.39:
@@ -6106,6 +6125,9 @@ packages:
 
   /@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+
+  /@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
 
   /@types/express-serve-static-core/4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
@@ -12632,7 +12654,7 @@ packages:
   /is-reference/1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
 
   /is-regex/1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -13494,6 +13516,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.13
     dev: true
 
   /make-dir/2.1.0:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "99322acfd60d5f879b021cda11937a02691c4608",
+  "pnpmShrinkwrapHash": "4e48e06303fd086b285e27a4467abb41b4dd13d8",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/c2pa-wc/package.json
+++ b/packages/c2pa-wc/package.json
@@ -75,7 +75,7 @@
     "@web/test-runner-core": "~0.10.26",
     "@open-wc/testing": "~3.1.5",
     "@web/dev-server-esbuild": "~0.3.0",
-    "@rollup/plugin-replace": "~4.0.0",
+    "@rollup/plugin-replace": "~5.0.2",
     "@web/dev-server-rollup": "~0.3.17",
     "@web/test-runner-browserstack": "~0.5.0",
     "@web/test-runner-puppeteer": "~0.10.5",

--- a/packages/c2pa/package.json
+++ b/packages/c2pa/package.json
@@ -75,7 +75,7 @@
     "@web/test-runner-browserstack": "~0.5.0",
     "@web/test-runner-puppeteer": "~0.10.5",
     "web-test-runner-jasmine": "~0.0.1",
-    "@rollup/plugin-replace": "~4.0.0",
+    "@rollup/plugin-replace": "~5.0.2",
     "rimraf": "^4.1.2",
     "@microsoft/api-extractor": "~7.31.1",
     "@rollup/plugin-json": "~4.1.0",

--- a/packages/c2pa/rollup.config.js
+++ b/packages/c2pa/rollup.config.js
@@ -62,7 +62,10 @@ const plugins = [
   typescript(),
   json(),
   replace({
-    'process.env.TOOLKIT_INTEGRITY': JSON.stringify(integrity),
+    preventAssignment: true,
+    values: {
+      TOOLKIT_INTEGRITY: JSON.stringify(integrity),
+    },
   }),
 ];
 

--- a/packages/c2pa/src/c2pa.ts
+++ b/packages/c2pa/src/c2pa.ts
@@ -213,6 +213,19 @@ export function generateVerifyUrl(assetUrl: string) {
 }
 
 /**
+ * Regular expression list of error names that we can ignore and still display the asset
+ * even though we can't inspect Content Credentials
+ */
+const ignoreErrors = [
+  // No embedded or remote provenance found in the asset
+  /^C2pa\(ProvenanceMissing\)$/,
+  // Could not parse JUMBF data
+  /^C2pa\(JumbfParseError\([^\)]+\)\)$/,
+  // JUMBF or required box not found
+  /^C2pa\(Jumbf(?:Box)?NotFound\)$/,
+];
+
+/**
  * Handles errors from the toolkit and fetches/processes remote manifests, if applicable.
  *
  * @param source - Source object representing the asset
@@ -229,23 +242,18 @@ function handleErrors(
   wasm: WebAssembly.Module,
   fetchRemote = true,
 ): Promise<ManifestStore | null> | null {
-  switch (error.name) {
-    case 'Toolkit(RemoteManifestUrl)':
-      if (fetchRemote && error.url) {
-        return fetchRemoteManifest(source, error.url, pool, wasm);
-      }
-      break;
-    // Allow these errors to still display the asset even though an embedded manifest can't be processed
-    case 'C2pa(ProvenanceMissing)':
-    case 'C2pa(JumbfParseError(InvalidJumbBox))':
-    case 'C2pa(JumbfNotFound)':
-      dbg('Missing or invalid provenance data found');
-      break;
-    default:
-      throw error;
+  if (error.name === 'Toolkit(RemoteManifestUrl)') {
+    if (fetchRemote && error.url) {
+      return fetchRemoteManifest(source, error.url, pool, wasm);
+    }
   }
 
-  return null;
+  if (ignoreErrors.some((re) => re.test(error.name))) {
+    dbg('Missing or invalid provenance data found', { error: error.name });
+    return null;
+  }
+
+  throw error;
 }
 
 async function fetchRemoteManifest(

--- a/packages/c2pa/src/c2pa.ts
+++ b/packages/c2pa/src/c2pa.ts
@@ -235,9 +235,11 @@ function handleErrors(
         return fetchRemoteManifest(source, error.url, pool, wasm);
       }
       break;
+    // Allow these errors to still display the asset even though an embedded manifest can't be processed
     case 'C2pa(ProvenanceMissing)':
+    case 'C2pa(JumbfParseError(InvalidJumbBox))':
     case 'C2pa(JumbfNotFound)':
-      dbg('No provenance data found');
+      dbg('Missing or invalid provenance data found');
       break;
     default:
       throw error;

--- a/packages/c2pa/src/c2pa.ts
+++ b/packages/c2pa/src/c2pa.ts
@@ -246,6 +246,7 @@ function handleErrors(
     if (fetchRemote && error.url) {
       return fetchRemoteManifest(source, error.url, pool, wasm);
     }
+    return null;
   }
 
   if (ignoreErrors.some((re) => re.test(error.name))) {

--- a/packages/c2pa/src/global.d.ts
+++ b/packages/c2pa/src/global.d.ts
@@ -8,3 +8,6 @@
  */
 
 declare module '@contentauth/detector/pkg/detector_bg.wasm';
+
+// Replacement variables declared in Rollup
+declare var TOOLKIT_INTEGRITY: Record<string, string>;

--- a/packages/c2pa/src/lib/wasm.ts
+++ b/packages/c2pa/src/lib/wasm.ts
@@ -22,7 +22,7 @@ export async function fetchWasm(
   pool: SdkWorkerPool,
   binaryUrl: string,
 ): Promise<WebAssembly.Module> {
-  const integrity = process.env.TOOLKIT_INTEGRITY as any;
+  const integrity = TOOLKIT_INTEGRITY;
   const wasmIntegrity = integrity?.['toolkit_bg.wasm'];
   dbg('Fetching WASM binary from url %s', binaryUrl, { expectedIntegrity: wasmIntegrity });
 

--- a/packages/c2pa/src/thumbnail.ts
+++ b/packages/c2pa/src/thumbnail.ts
@@ -35,6 +35,10 @@ export function createThumbnail(
   resourceStore: ResourceStore,
   resourceReference: ResourceReference,
 ): Thumbnail | null {
+  if (!resourceStore || !resourceReference) {
+    return null;
+  }
+
   const blob = getResourceAsBlob(resourceStore, resourceReference);
 
   if (!blob) {

--- a/packages/c2pa/tsconfig.json
+++ b/packages/c2pa/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES6"
+    "target": "es2017"
   },
   "include": ["**/*"],
   "exclude": ["dist/**/*", "test/**/*"]

--- a/packages/detector/Cargo.lock
+++ b/packages/detector/Cargo.lock
@@ -10,12 +10,6 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -26,15 +20,15 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "console_log"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
 dependencies = [
  "log",
  "wasm-bindgen",
@@ -54,14 +48,7 @@ dependencies = [
  "serde_derive",
  "twoway",
  "wasm-bindgen",
- "wee_alloc",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "itoa"
@@ -79,18 +66,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.135"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -98,12 +79,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "once_cell"
@@ -146,11 +121,10 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618365e8e586c22123d692b72a7d791d5ee697817b65a218cdf12a98870af0f7"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
- "fnv",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -226,7 +200,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -285,37 +259,3 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/packages/detector/Cargo.toml
+++ b/packages/detector/Cargo.toml
@@ -9,15 +9,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 console_error_panic_hook = "0.1.6"
-console_log = {version = "0.2", features = ["color"]}
+console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.14"
-serde = {version = "1.0.127", features = ["derive"]}
-serde-wasm-bindgen = "0.3.0"
+serde = { version = "1.0.127", features = ["derive"] }
+serde-wasm-bindgen = "0.5.0"
 serde_bytes = "0.11.5"
 serde_derive = "1.0.126"
 twoway = "0.2.2"
-wasm-bindgen = {version = "0.2.83", features = ["serde-serialize"]}
-wee_alloc = "0.4.5"
+wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 
 [profile.release]
 lto = true

--- a/packages/detector/package.json
+++ b/packages/detector/package.json
@@ -18,10 +18,10 @@
     "pkg/**/*"
   ],
   "scripts": {
-    "dev": "nodemon -x wasm-pack -e rs -w src -w -- build --dev --out-name detector --target web",
-    "build": "wasm-pack --quiet build --out-name detector --release --target web && rimraf pkg/.gitignore pkg/package.json",
+    "dev": "nodemon -x wasm-pack -e rs -w src -w -- build --dev --weak-refs --reference-types --out-name detector --target web",
+    "build": "wasm-pack --quiet build --out-name detector --release --weak-refs --reference-types --target web && rimraf pkg/.gitignore pkg/package.json",
     "build:release": "rushx build",
-    "build:verbose": "wasm-pack --verbose build --out-name detector --release --target web && rimraf pkg/.gitignore pkg/package.json",
+    "build:verbose": "wasm-pack --verbose build --out-name detector --release --weak-refs --reference-types --target web && rimraf pkg/.gitignore pkg/package.json",
     "clean": "rimraf ./pkg"
   },
   "devDependencies": {

--- a/packages/detector/src/lib.rs
+++ b/packages/detector/src/lib.rs
@@ -9,11 +9,6 @@ use std::panic;
 use twoway::find_bytes;
 use wasm_bindgen::prelude::*;
 
-extern crate wee_alloc;
-
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[wasm_bindgen(start)]
 pub fn main() {
     panic::set_hook(Box::new(console_error_panic_hook::hook));

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
     "@rushstack/eslint-config": "~2.6.0",
     "@types/react": "^16.13.1",
     "@rollup/plugin-alias": "~3.1.9",
-    "@rollup/plugin-replace": "~4.0.0",
+    "@rollup/plugin-replace": "~5.0.2",
     "rimraf": "^4.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/toolkit/Cargo.lock
+++ b/packages/toolkit/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "bytes",
  "chrono",
  "ciborium",
- "console_log",
+ "console_log 0.2.0",
  "conv",
  "coset",
  "extfmt",
@@ -229,7 +229,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde-transcode",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.4.5",
  "serde_bytes",
  "serde_cbor",
  "serde_derive",
@@ -256,12 +256,12 @@ version = "0.18.1-1"
 dependencies = [
  "c2pa",
  "console_error_panic_hook",
- "console_log",
+ "console_log 1.0.0",
  "js-sys",
  "log",
  "serde",
  "serde-transcode",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.5.0",
  "serde_bytes",
  "serde_cbor",
  "serde_derive",
@@ -364,6 +364,17 @@ name = "console_log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
 dependencies = [
  "log",
  "wasm-bindgen",
@@ -1490,6 +1501,17 @@ name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
  "js-sys",
  "serde",

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -10,13 +10,13 @@ crate-type = ["cdylib"]
 [dependencies]
 c2pa = { version = "0.18.1", features = ["serialize_thumbnails"] }
 console_error_panic_hook = "0.1.7"
-console_log = { version = "0.2", features = ["color"] }
+console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.14"
 js-sys = "0.3.56"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.79"
-serde-wasm-bindgen = "0.4.2"
+serde-wasm-bindgen = "0.5.0"
 serde_bytes = "0.11.5"
 serde_derive = "1.0.126"
 serde-transcode = "1.1.1"

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@contentauth/testing": "workspace:*",
-    "@rollup/plugin-replace": "~4.0.0",
+    "@rollup/plugin-replace": "~5.0.2",
     "@types/jasmine": "~4.0.3",
     "@web/dev-server-esbuild": "~0.3.0",
     "@web/dev-server-rollup": "~0.3.17",

--- a/packages/toolkit/scripts/build.js
+++ b/packages/toolkit/scripts/build.js
@@ -46,7 +46,7 @@ async function buildWasm(opts) {
   const cmd = `wasm-pack`;
   const mode = opts.dev ? 'dev' : 'release';
   const verbosity = opts.verbose ? 'verbose' : 'quiet';
-  const args = `build --${verbosity} --out-name toolkit --${mode} --target web`;
+  const args = `build --weak-refs --${verbosity} --out-name toolkit --${mode} --target web`;
 
   opts.verbose && console.log(`Building in ${mode.toUpperCase()} mode`);
 

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "7.27.0",
+  "pnpmVersion": "7.30.0",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",


### PR DESCRIPTION
## Changes in this pull request
- Fixes error on `read` that would get triggered if an ingredient doesn't have a thumbnail
- Allows assets that have invalid JUMBF box to have their sources passed through to the client during a `read` request instead instead of throwing an error so that the asset can still be displayed
- Fixes TypeScript errors by updating our `target` to `es2017` to use some newer (but widely supported) JavaScript APIs, as well as removing `process.env` in favor of a constant for the integrity logic
- Updates detector and toolkit to add the new `--weak-refs` flag available in [wasm-pack 0.11.0](https://github.com/rustwasm/wasm-pack/blob/master/CHANGELOG.md#-fixes), as well as adding `--reference-types` to detector (omitted on toolkit since we get a memory access error in Safari)
- Remove dependency on [wee_alloc](https://github.com/rustwasm/wee_alloc) since it is unmaintained and has a reported memory leak
- Updates Rust dependencies and `@rollup/plugin-replace`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
