### PR TITLE
[c2pa-wc] Fix floating-ui build issue

### DIFF
--- a/packages/c2pa-wc/package.json
+++ b/packages/c2pa-wc/package.json
@@ -105,6 +105,7 @@
     "@rollup/pluginutils": "~4.2.1",
     "eslint-plugin-import": "^2.26.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "@typescript-eslint/parser": "^5.20.0"
+    "@typescript-eslint/parser": "^5.20.0",
+    "@rollup/plugin-replace": "~5.0.2"
   }
 }

--- a/packages/c2pa-wc/rollup.config.js
+++ b/packages/c2pa-wc/rollup.config.js
@@ -16,6 +16,7 @@ import merge from 'deepmerge';
 import fg from 'fast-glob';
 import path from 'path';
 import postcss from 'rollup-plugin-postcss';
+import replace from '@rollup/plugin-replace';
 
 const litSvg = require('./etc/rollup/plugins/lit-svg.cjs');
 
@@ -72,5 +73,8 @@ export default merge(baseConfig, {
     commonjs(),
     typescript(),
     postcss(),
+    replace({
+      'process.env.NODE_ENV': "'production'",
+    }),
   ],
 });


### PR DESCRIPTION
## Changes in this pull request

I was not able to use `cai-manifest-summary` due to an issue in `dist/components/Popover/Popover.js`. This issue was caused by leftover `process.env.NODE_ENV` checks being run by the browser, which doesn't know `process`. This is a  known issue ([one](https://github.com/floating-ui/floating-ui/issues/1713), [two](https://github.com/floating-ui/floating-ui/issues/1506)) caused by a dependency, `@floating-ui/dom`.

This PR uses a fix recommended in the linked issues. I wasn't able to find an approriate variable indicating prod or dev env, so I have hardcoded it to `production`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
