### PR TITLE
Fix for i128 serialization issue in Wasm, update c2pa-rs to 0.25.1

### DIFF
--- a/common/changes/@contentauth/toolkit/fix-i128-cbor-to-json_2023-07-19-19-57.json
+++ b/common/changes/@contentauth/toolkit/fix-i128-cbor-to-json_2023-07-19-19-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@contentauth/toolkit",
+      "comment": "Update c2pa-rs to 0.25.1, fix i128 serialization issue in Wasm",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@contentauth/toolkit"
+}

--- a/packages/toolkit/Cargo.lock
+++ b/packages/toolkit/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -114,6 +114,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -227,14 +233,14 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "c2pa"
-version = "0.23.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4768e9005421b4f649b28799e283c03c314cb5f8b7be2069bb043800300d22d5"
+checksum = "3a9d8ae5e6eafb65e5e533750bd6cc9e88d06733dc481a3815ae7e544fadfde4"
 dependencies = [
  "asn1-rs",
  "async-trait",
  "atree",
- "base64",
+ "base64 0.21.2",
  "bcder",
  "blake3",
  "byteorder",
@@ -242,12 +248,13 @@ dependencies = [
  "bytes",
  "chrono",
  "ciborium",
- "console_log 0.2.0",
+ "console_log",
  "conv",
  "coset",
  "extfmt",
  "fast-xml",
  "getrandom",
+ "half",
  "hex",
  "img-parts",
  "instant",
@@ -265,7 +272,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde-transcode",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen",
  "serde_bytes",
  "serde_cbor",
  "serde_derive",
@@ -292,12 +299,12 @@ version = "0.23.1-1"
 dependencies = [
  "c2pa",
  "console_error_panic_hook",
- "console_log 1.0.0",
+ "console_log",
  "js-sys",
  "log",
  "serde",
  "serde-transcode",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "serde_bytes",
  "serde_cbor",
  "serde_derive",
@@ -388,17 +395,6 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -641,7 +637,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1019,7 +1015,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -1083,9 +1079,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1249,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -1263,17 +1259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1308,20 +1293,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.102",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1443,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1504,7 +1489,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1639,7 +1624,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "chunked_transfer",
  "flate2",
  "log",

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -8,14 +8,14 @@ version = "0.23.1-1"
 crate-type = ["cdylib"]
 
 [dependencies]
-c2pa = { version = "0.23.1", features = ["serialize_thumbnails"] }
+c2pa = { version = "0.25.1", features = ["serialize_thumbnails"] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.14"
 js-sys = "0.3.56"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_cbor = "0.11.2"
-serde_json = "1.0.79"
+serde_json = { version = "1.0.103", features = ["arbitrary_precision"] }
 serde-wasm-bindgen = "0.5.0"
 serde_bytes = "0.11.5"
 serde_derive = "1.0.126"


### PR DESCRIPTION
## Changes in this pull request
One of the test images we had contained i128 values in its CBOR assertion data. As part as the process to transfer these values over to the browser, we attempt to serialize this as JSON, however wasm and JavaScript/JSON only supports up to i64 values (JSON deserialization in JavaScript can't use the `BigInt` primitive, so it can only handle numbers up to the `MAX_SAFE_INTEGER` size).

Due to this, the JSON serialization was failing in a Wasm context, and we were getting an error encoding the assertion data, resulting in an incomplete manifest store.

This fix adds support for the undocumented `arbitrary_precision` feature in serde_json, which I _believe_ will map the value to a string internally to avoid these (de)serialization issues.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
