### PR TITLE
ManifestSummary popover heigh max to 100vh in small viewport

### DIFF
--- a/packages/c2pa-wc/src/components/ManifestSummary/ManifestSummary.ts
+++ b/packages/c2pa-wc/src/components/ManifestSummary/ManifestSummary.ts
@@ -77,6 +77,9 @@ export class ManifestSummary extends Configurable(LitElement, defaultConfig) {
       css`
         #container {
           width: var(--cai-manifest-summary-width, 320px);
+          display: flex;
+          flex-direction: column;
+          max-height: calc(100vh);
         }
 
         #content-container {
@@ -97,6 +100,8 @@ export class ManifestSummary extends Configurable(LitElement, defaultConfig) {
 
           overflow-y: auto;
           overflow-x: hidden;
+          flex-grow: 1;
+          flex-shrink: 1;
         }
 
         #content-container > *:not(:first-child):not([empty]),


### PR DESCRIPTION
## Changes in this pull request
The root popover, ManifestSummary, expands beyond the bounds of the page in small viewports. See https://github.com/contentauth/c2pa-js/issues/93. This change makes `#container` flex flow column layout so in cases where `#content-container` is larger than `#container`, the 'view more' button stays on screen.

https://github.com/contentauth/c2pa-js/assets/7935599/57d2857c-5d95-42de-b509-fe92502803be

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
