### PR TITLE
Make translation files compatible with ALF

### DIFF
--- a/packages/c2pa-wc/i18n/en-US.json
+++ b/packages/c2pa-wc/i18n/en-US.json
@@ -1,0 +1,22 @@
+{
+  "ai-tool-used.header": "AI tool used",
+  "content-summary.header": "Content summary",
+  "content-summary.content.aiGenerated": "This content was generated with an AI tool.",
+  "content-summary.content.composite": "This image combines multiple pieces of content. At least one was generated with an AI tool.",
+  "manifest-summary.viewMore": "Inspect",
+  "manifest-summary.error": "Content Credentials unavailable or invalid",
+  "minimum-viable-provenance.header": "Content Credentials",
+  "minimum-viable-provenance.helpText": "Attribution and history data attached to this content",
+  "minimum-viable-provenance.invalidDate": "Invalid date",
+  "minimum-viable-provenance.issuedBy": "Issued by",
+  "minimum-viable-provenance.on": "on",
+  "produced-by.header": "Produced by",
+  "produced-by.helpText": "Chosen name of the person who exported this content",
+  "produced-with.header": "App or device used",
+  "produced-with.helpText": "Software used to make this content",
+  "produced-with.beta": "Content Credentials (Beta)",
+  "social-media.header": "Social media",
+  "social-media.helpText": "Social media accounts connected to the producer of this content",
+  "web3.header": "Web3",
+  "web3.copied": "Copied!"
+}

--- a/packages/c2pa/i18n/cs-CZ.json
+++ b/packages/c2pa/i18n/cs-CZ.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Byly upraveny vlastnosti, jako je tón, sytost, křivky, stíny nebo světla",
-        "label": "Úpravy barev nebo expozice"
-      },
-      "c2pa.created": {
-        "description": "Byl vytvořen nový soubor nebo obsah",
-        "label": "Vytvořeno"
-      },
-      "c2pa.cropped": {
-        "description": "Byly použity nástroje pro oříznutí, zmenšení nebo rozšíření viditelné oblasti obsahu",
-        "label": "Úpravy oříznutí"
-      },
-      "c2pa.drawing": {
-        "description": "Byly použity nástroje, jako jsou tužky, štětce, gumy nebo nástroje tvar, cesta nebo pero",
-        "label": "Úpravy kresby"
-      },
-      "c2pa.edited": {
-        "description": "Byly provedeny další změny",
-        "label": "Další úpravy"
-      },
-      "c2pa.filtered": {
-        "description": "Byly použity nástroje, jako jsou filtry, styly nebo efekty, ke změně vzhledu",
-        "label": "Úpravy filtrů nebo stylů"
-      },
-      "c2pa.opened": {
-        "description": "Byl otevřen existující soubor",
-        "label": "Otevřeno"
-      },
-      "c2pa.orientation": {
-        "description": "Byla změněna poloha nebo orientace (otočení, převrácení atd.)",
-        "label": "Orientace úpravy"
-      },
-      "c2pa.placed": {
-        "description": "Do tohoto souboru byl přidán existující obsah",
-        "label": "Importováno"
-      },
-      "c2pa.resized": {
-        "description": "Byly změněny rozměry nebo velikost souboru",
-        "label": "Změny velikosti"
-      },
-      "c2pa.unknown": {
-        "description": "Byly provedeny další úpravy nebo aktivita, kterou nebylo možné rozpoznat",
-        "label": "Neznámé úpravy nebo aktivita"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Byly upraveny vlastnosti, jako je tón, sytost, křivky, stíny nebo světla",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Úpravy barev nebo expozice",
+  "selectors.editsAndActivity.c2pa.created.description": "Byl vytvořen nový soubor nebo obsah",
+  "selectors.editsAndActivity.c2pa.created.label": "Vytvořeno",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Byly použity nástroje pro oříznutí, zmenšení nebo rozšíření viditelné oblasti obsahu",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Úpravy oříznutí",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Byly použity nástroje, jako jsou tužky, štětce, gumy nebo nástroje tvar, cesta nebo pero",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Úpravy kresby",
+  "selectors.editsAndActivity.c2pa.edited.description": "Byly provedeny další změny",
+  "selectors.editsAndActivity.c2pa.edited.label": "Další úpravy",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Byly použity nástroje, jako jsou filtry, styly nebo efekty, ke změně vzhledu",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Úpravy filtrů nebo stylů",
+  "selectors.editsAndActivity.c2pa.opened.description": "Byl otevřen existující soubor",
+  "selectors.editsAndActivity.c2pa.opened.label": "Otevřeno",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Byla změněna poloha nebo orientace (otočení, převrácení atd.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientace úpravy",
+  "selectors.editsAndActivity.c2pa.placed.description": "Do tohoto souboru byl přidán existující obsah",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importováno",
+  "selectors.editsAndActivity.c2pa.resized.description": "Byly změněny rozměry nebo velikost souboru",
+  "selectors.editsAndActivity.c2pa.resized.label": "Změny velikosti",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Byly provedeny další úpravy nebo aktivita, kterou nebylo možné rozpoznat",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Neznámé úpravy nebo aktivita"
 }

--- a/packages/c2pa/i18n/da-DK.json
+++ b/packages/c2pa/i18n/da-DK.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Justerede egenskaber såsom tone, mætning, kurver, skygger eller fremhævninger",
-        "label": "Farve- eller eksponeringsredigeringer"
-      },
-      "c2pa.created": {
-        "description": "Oprettede en ny fil eller nyt indhold",
-        "label": "Oprettede"
-      },
-      "c2pa.cropped": {
-        "description": "Brugte beskæringsværktøjer til at reducere eller udvide synligt indholdsområde",
-        "label": "Beskæring af redigeringer"
-      },
-      "c2pa.drawing": {
-        "description": "Brugte værktøjer såsom blyanter, pensler, viskelædere eller form-, sti- eller penneværktøjer",
-        "label": "Tegneredigeringer"
-      },
-      "c2pa.edited": {
-        "description": "Foretog andre ændringer",
-        "label": "Andre redigeringer"
-      },
-      "c2pa.filtered": {
-        "description": "Brugte værktøjer såsom filtre, formater eller effekter til at ændre udseende",
-        "label": "Filter- eller formatredigeringer"
-      },
-      "c2pa.opened": {
-        "description": "Åbnede en allerede eksisterende fil",
-        "label": "Åbnede"
-      },
-      "c2pa.orientation": {
-        "description": "Ændrede placering eller retning (roteret, vendt osv.)",
-        "label": "Retning redigeringer"
-      },
-      "c2pa.placed": {
-        "description": "Føjede allerede eksisterende indhold til denne fil",
-        "label": "Importerede"
-      },
-      "c2pa.resized": {
-        "description": "Ændrede dimensioner eller filstørrelse",
-        "label": "Ændring af størrelse på redigeringer"
-      },
-      "c2pa.unknown": {
-        "description": "Foretog andre redigeringer eller aktiviteter, der ikke kunne genkendes",
-        "label": "Ukendte redigeringer eller ukendt aktivitet"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Justerede egenskaber såsom tone, mætning, kurver, skygger eller fremhævninger",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Farve- eller eksponeringsredigeringer",
+  "selectors.editsAndActivity.c2pa.created.description": "Oprettede en ny fil eller nyt indhold",
+  "selectors.editsAndActivity.c2pa.created.label": "Oprettede",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Brugte beskæringsværktøjer til at reducere eller udvide synligt indholdsområde",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Beskæring af redigeringer",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Brugte værktøjer såsom blyanter, pensler, viskelædere eller form-, sti- eller penneværktøjer",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Tegneredigeringer",
+  "selectors.editsAndActivity.c2pa.edited.description": "Foretog andre ændringer",
+  "selectors.editsAndActivity.c2pa.edited.label": "Andre redigeringer",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Brugte værktøjer såsom filtre, formater eller effekter til at ændre udseende",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Filter- eller formatredigeringer",
+  "selectors.editsAndActivity.c2pa.opened.description": "Åbnede en allerede eksisterende fil",
+  "selectors.editsAndActivity.c2pa.opened.label": "Åbnede",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Ændrede placering eller retning (roteret, vendt osv.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Retning redigeringer",
+  "selectors.editsAndActivity.c2pa.placed.description": "Føjede allerede eksisterende indhold til denne fil",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importerede",
+  "selectors.editsAndActivity.c2pa.resized.description": "Ændrede dimensioner eller filstørrelse",
+  "selectors.editsAndActivity.c2pa.resized.label": "Ændring af størrelse på redigeringer",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Foretog andre redigeringer eller aktiviteter, der ikke kunne genkendes",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Ukendte redigeringer eller ukendt aktivitet"
 }

--- a/packages/c2pa/i18n/de-DE.json
+++ b/packages/c2pa/i18n/de-DE.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Angepasste Eigenschaften wie Farbton, Sättigung, Kurven, Schatten oder Glanzlichter",
-        "label": "Änderung von Farbe oder Belichtung"
-      },
-      "c2pa.created": {
-        "description": "Neue Datei oder neuen Inhalt erstellt",
-        "label": "Erstellt"
-      },
-      "c2pa.cropped": {
-        "description": "Verwendete Zuschneidewerkzeuge, Verkleinerung oder Erweiterung des sichtbaren Inhaltsbereichs",
-        "label": "Zuschneiden von Änderungen"
-      },
-      "c2pa.drawing": {
-        "description": "Verwendete Werkzeuge wie Stifte, Pinsel, Radierer oder Form-, Pfad- oder Zeichenstift-Werkzeuge",
-        "label": "Zeichnungsänderungen"
-      },
-      "c2pa.edited": {
-        "description": "Vorgenommene sonstige Änderungen",
-        "label": "Sonstige Änderungen"
-      },
-      "c2pa.filtered": {
-        "description": "Verwendete Tools wie Filter, Stile, Formate oder Effekte, die das Erscheinungsbild ändern",
-        "label": "Änderungen filtern oder gestalten"
-      },
-      "c2pa.opened": {
-        "description": "Vorhandene Datei geöffnet",
-        "label": "Geöffnet"
-      },
-      "c2pa.orientation": {
-        "description": "Position oder Ausrichtung geändert (gedreht, gespiegelt usw.)",
-        "label": "Ausrichtung Änderungen"
-      },
-      "c2pa.placed": {
-        "description": "Vorhandenen Inhalt zu dieser Datei hinzugefügt",
-        "label": "Importiert"
-      },
-      "c2pa.resized": {
-        "description": "Geänderte Abmessungen oder Dateigröße",
-        "label": "Größenänderungen"
-      },
-      "c2pa.unknown": {
-        "description": "Andere Änderungen oder Aktivitäten durchgeführt, die nicht erkannt werden konnten",
-        "label": "Unbekannte Änderungen oder Aktivitäten"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Angepasste Eigenschaften wie Farbton, Sättigung, Kurven, Schatten oder Glanzlichter",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Änderung von Farbe oder Belichtung",
+  "selectors.editsAndActivity.c2pa.created.description": "Neue Datei oder neuen Inhalt erstellt",
+  "selectors.editsAndActivity.c2pa.created.label": "Erstellt",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Verwendete Zuschneidewerkzeuge, Verkleinerung oder Erweiterung des sichtbaren Inhaltsbereichs",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Zuschneiden von Änderungen",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Verwendete Werkzeuge wie Stifte, Pinsel, Radierer oder Form-, Pfad- oder Zeichenstift-Werkzeuge",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Zeichnungsänderungen",
+  "selectors.editsAndActivity.c2pa.edited.description": "Vorgenommene sonstige Änderungen",
+  "selectors.editsAndActivity.c2pa.edited.label": "Sonstige Änderungen",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Verwendete Tools wie Filter, Stile, Formate oder Effekte, die das Erscheinungsbild ändern",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Änderungen filtern oder gestalten",
+  "selectors.editsAndActivity.c2pa.opened.description": "Vorhandene Datei geöffnet",
+  "selectors.editsAndActivity.c2pa.opened.label": "Geöffnet",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Position oder Ausrichtung geändert (gedreht, gespiegelt usw.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Ausrichtung Änderungen",
+  "selectors.editsAndActivity.c2pa.placed.description": "Vorhandenen Inhalt zu dieser Datei hinzugefügt",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importiert",
+  "selectors.editsAndActivity.c2pa.resized.description": "Geänderte Abmessungen oder Dateigröße",
+  "selectors.editsAndActivity.c2pa.resized.label": "Größenänderungen",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Andere Änderungen oder Aktivitäten durchgeführt, die nicht erkannt werden konnten",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Unbekannte Änderungen oder Aktivitäten"
 }

--- a/packages/c2pa/i18n/en-US.json
+++ b/packages/c2pa/i18n/en-US.json
@@ -1,86 +1,42 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Adjusted properties like tone, saturation, curves, shadows, or highlights",
-        "label": "Color or exposure edits"
-      },
-      "c2pa.converted": {
-        "description": "The format of the asset was changed",
-        "label": "Converted asset"
-      },
-      "c2pa.created": {
-        "description": "Created a new file or content",
-        "label": "Created"
-      },
-      "c2pa.cropped": {
-        "description": "Used cropping tools, reducing or expanding visible content area",
-        "label": "Cropping edits"
-      },
-      "c2pa.deleted": {
-        "description": "Deleted visual areas or durations of content",
-        "label": "Deleted content"
-      },
-      "c2pa.drawing": {
-        "description": "Used tools like pencils, brushes, erasers, or shape, path, or pen tools",
-        "label": "Drawing edits"
-      },
-      "c2pa.dubbed": {
-        "description": "Replaced audio",
-        "label": "Dubbed"
-      },
-      "c2pa.edited": {
-        "description": "Made other changes",
-        "label": "Other edits"
-      },
-      "c2pa.filtered": {
-        "description": "Used tools like filters, styles, or effects to change appearance",
-        "label": "Filter or style edits"
-      },
-      "c2pa.opened": {
-        "description": "Opened a pre-existing file",
-        "label": "Opened"
-      },
-      "c2pa.orientation": {
-        "description": "Changed position or orientation (rotated, flipped, etc.)",
-        "label": "Orientation edits"
-      },
-      "c2pa.placed": {
-        "description": "Added pre-existing content to this file",
-        "label": "Imported"
-      },
-      "c2pa.published": {
-        "description": "Received and distributed image",
-        "label": "Published image"
-      },
-      "c2pa.removed": {
-        "description": "One or more assets were removed from the file",
-        "label": "Asset removed"
-      },
-      "c2pa.repackaged": {
-        "description": "Asset was repackaged without being processed",
-        "label": "Repackaged asset"
-      },
-      "c2pa.resized": {
-        "description": "Changed dimensions or file size",
-        "label": "Resizing edits"
-      },
-      "c2pa.transcoded": {
-        "description": "Processed or compressed an asset to optimize for display",
-        "label": "Processed asset"
-      },
-      "c2pa.translated": {
-        "description": "Translated content",
-        "label": "Translated"
-      },
-      "c2pa.unknown": {
-        "description": "Performed other edits or activity that couldn't be recognized",
-        "label": "Unknown edits or activity"
-      },
-      "c2pa.edited.metadata": {
-        "description": "Made changes to file metadata",
-        "label": "Metadata changes"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Adjusted properties like tone, saturation, curves, shadows, or highlights",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Color or exposure edits",
+  "selectors.editsAndActivity.c2pa.converted.description": "The format of the asset was changed",
+  "selectors.editsAndActivity.c2pa.converted.label": "Converted asset",
+  "selectors.editsAndActivity.c2pa.created.description": "Created a new file or content",
+  "selectors.editsAndActivity.c2pa.created.label": "Created",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Used cropping tools, reducing or expanding visible content area",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Cropping edits",
+  "selectors.editsAndActivity.c2pa.deleted.description": "Deleted visual areas or durations of content",
+  "selectors.editsAndActivity.c2pa.deleted.label": "Deleted content",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Used tools like pencils, brushes, erasers, or shape, path, or pen tools",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Drawing edits",
+  "selectors.editsAndActivity.c2pa.dubbed.description": "Replaced audio",
+  "selectors.editsAndActivity.c2pa.dubbed.label": "Dubbed",
+  "selectors.editsAndActivity.c2pa.edited.description": "Made other changes",
+  "selectors.editsAndActivity.c2pa.edited.label": "Other edits",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Used tools like filters, styles, or effects to change appearance",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Filter or style edits",
+  "selectors.editsAndActivity.c2pa.opened.description": "Opened a pre-existing file",
+  "selectors.editsAndActivity.c2pa.opened.label": "Opened",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Changed position or orientation (rotated, flipped, etc.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientation edits",
+  "selectors.editsAndActivity.c2pa.placed.description": "Added pre-existing content to this file",
+  "selectors.editsAndActivity.c2pa.placed.label": "Imported",
+  "selectors.editsAndActivity.c2pa.published.description": "Received and distributed image",
+  "selectors.editsAndActivity.c2pa.published.label": "Published image",
+  "selectors.editsAndActivity.c2pa.removed.description": "One or more assets were removed from the file",
+  "selectors.editsAndActivity.c2pa.removed.label": "Asset removed",
+  "selectors.editsAndActivity.c2pa.repackaged.description": "Asset was repackaged without being processed",
+  "selectors.editsAndActivity.c2pa.repackaged.label": "Repackaged asset",
+  "selectors.editsAndActivity.c2pa.resized.description": "Changed dimensions or file size",
+  "selectors.editsAndActivity.c2pa.resized.label": "Resizing edits",
+  "selectors.editsAndActivity.c2pa.transcoded.description": "Processed or compressed an asset to optimize for display",
+  "selectors.editsAndActivity.c2pa.transcoded.label": "Processed asset",
+  "selectors.editsAndActivity.c2pa.translated.description": "Translated content",
+  "selectors.editsAndActivity.c2pa.translated.label": "Translated",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Performed other edits or activity that couldn't be recognized",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Unknown edits or activity",
+  "selectors.editsAndActivity.c2pa.edited.metadata.description": "Made changes to file metadata",
+  "selectors.editsAndActivity.c2pa.edited.metadata.label": "Metadata changes"
 }

--- a/packages/c2pa/i18n/es-ES.json
+++ b/packages/c2pa/i18n/es-ES.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Se han ajustado propiedades como el tono, la saturación, las curvas, las sombras o las luces",
-        "label": "Ediciones de color o exposición"
-      },
-      "c2pa.created": {
-        "description": "Se ha creado un nuevo archivo o contenido",
-        "label": "Fecha de creación"
-      },
-      "c2pa.cropped": {
-        "description": "Se han usado herramientas de recorte, lo que reduce o expande el área de contenido visible",
-        "label": "Ediciones de recorte"
-      },
-      "c2pa.drawing": {
-        "description": "Se han usado herramientas como lápices, pinceles, borradores o herramientas de formas, trazados o bolígrafos",
-        "label": "Ediciones de dibujo"
-      },
-      "c2pa.edited": {
-        "description": "Se han hecho otros cambios",
-        "label": "Otras ediciones"
-      },
-      "c2pa.filtered": {
-        "description": "Se han usado herramientas como filtros, estilos o efectos para cambiar la apariencia",
-        "label": "Ediciones de filtro o estilo"
-      },
-      "c2pa.opened": {
-        "description": "Se ha abierto un archivo preexistente",
-        "label": "Abierto"
-      },
-      "c2pa.orientation": {
-        "description": "Se ha cambiado la posición u orientación (girado, volteado, etc.)",
-        "label": "Ediciones de orientación"
-      },
-      "c2pa.placed": {
-        "description": "Se ha añadido contenido preexistente a este archivo",
-        "label": "Importado"
-      },
-      "c2pa.resized": {
-        "description": "Se han modificado las dimensiones o el tamaño del archivo",
-        "label": "Ediciones de cambio de tamaño"
-      },
-      "c2pa.unknown": {
-        "description": "Se han realizado otras ediciones o actividades que no se han podido reconocer",
-        "label": "Ediciones o actividad desconocidas"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Se han ajustado propiedades como el tono, la saturación, las curvas, las sombras o las luces",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Ediciones de color o exposición",
+  "selectors.editsAndActivity.c2pa.created.description": "Se ha creado un nuevo archivo o contenido",
+  "selectors.editsAndActivity.c2pa.created.label": "Fecha de creación",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Se han usado herramientas de recorte, lo que reduce o expande el área de contenido visible",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Ediciones de recorte",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Se han usado herramientas como lápices, pinceles, borradores o herramientas de formas, trazados o bolígrafos",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Ediciones de dibujo",
+  "selectors.editsAndActivity.c2pa.edited.description": "Se han hecho otros cambios",
+  "selectors.editsAndActivity.c2pa.edited.label": "Otras ediciones",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Se han usado herramientas como filtros, estilos o efectos para cambiar la apariencia",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Ediciones de filtro o estilo",
+  "selectors.editsAndActivity.c2pa.opened.description": "Se ha abierto un archivo preexistente",
+  "selectors.editsAndActivity.c2pa.opened.label": "Abierto",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Se ha cambiado la posición u orientación (girado, volteado, etc.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Ediciones de orientación",
+  "selectors.editsAndActivity.c2pa.placed.description": "Se ha añadido contenido preexistente a este archivo",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importado",
+  "selectors.editsAndActivity.c2pa.resized.description": "Se han modificado las dimensiones o el tamaño del archivo",
+  "selectors.editsAndActivity.c2pa.resized.label": "Ediciones de cambio de tamaño",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Se han realizado otras ediciones o actividades que no se han podido reconocer",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Ediciones o actividad desconocidas"
 }

--- a/packages/c2pa/i18n/fi-FI.json
+++ b/packages/c2pa/i18n/fi-FI.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Säädetty ominaisuuksia, kuten sävyä, kylläisyyttä, käyriä, varjoja tai kohokohtia",
-        "label": "Väreihin tai valotukseen liittyvät muokkaukset"
-      },
-      "c2pa.created": {
-        "description": "Luotu uusi tiedosto tai uutta sisältöä",
-        "label": "Luotu"
-      },
-      "c2pa.cropped": {
-        "description": "Käytetty rajaustyökaluja, vähennetty tai laajennettu näkyvää sisältöaluetta",
-        "label": "Rajaukseen liittyvät muokkaukset"
-      },
-      "c2pa.drawing": {
-        "description": "Käytetty työkaluja, kuten kyniä, siveltimiä, pyyhekumeja tai muoto-, reitti- tai kynätyökaluja",
-        "label": "Piirtämiseen liittyvät muokkaukset"
-      },
-      "c2pa.edited": {
-        "description": "Tehty muita muutoksia",
-        "label": "Muut muokkaukset"
-      },
-      "c2pa.filtered": {
-        "description": "Käytetty työkaluja, kuten ulkoasun muuttamiseen tarkoitettuja suodattimia, tyylejä tai tehosteita",
-        "label": "Suodattimeen tai tyyliin liittyvät muokkaukset"
-      },
-      "c2pa.opened": {
-        "description": "Avattu olemassa oleva tiedosto",
-        "label": "Avattu"
-      },
-      "c2pa.orientation": {
-        "description": "Muutettu paikkaa tai suuntaa (kierretty, käännetty jne.)",
-        "label": "Suuntaan liittyvät muokkaukset"
-      },
-      "c2pa.placed": {
-        "description": "Lisätty olemassa olevaa sisältöä tähän tiedostoon",
-        "label": "Tuotu"
-      },
-      "c2pa.resized": {
-        "description": "Muutettu mittasuhteita tai tiedostokokoa",
-        "label": "Koon muuttamiseen liittyvät muokkaukset"
-      },
-      "c2pa.unknown": {
-        "description": "Suoritettu muita muokkauksia tai toimintoja, joita ei tunnistettu",
-        "label": "Tuntemattomat muokkaukset tai tuntematon toiminta"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Säädetty ominaisuuksia, kuten sävyä, kylläisyyttä, käyriä, varjoja tai kohokohtia",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Väreihin tai valotukseen liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.created.description": "Luotu uusi tiedosto tai uutta sisältöä",
+  "selectors.editsAndActivity.c2pa.created.label": "Luotu",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Käytetty rajaustyökaluja, vähennetty tai laajennettu näkyvää sisältöaluetta",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Rajaukseen liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Käytetty työkaluja, kuten kyniä, siveltimiä, pyyhekumeja tai muoto-, reitti- tai kynätyökaluja",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Piirtämiseen liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.edited.description": "Tehty muita muutoksia",
+  "selectors.editsAndActivity.c2pa.edited.label": "Muut muokkaukset",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Käytetty työkaluja, kuten ulkoasun muuttamiseen tarkoitettuja suodattimia, tyylejä tai tehosteita",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Suodattimeen tai tyyliin liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.opened.description": "Avattu olemassa oleva tiedosto",
+  "selectors.editsAndActivity.c2pa.opened.label": "Avattu",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Muutettu paikkaa tai suuntaa (kierretty, käännetty jne.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Suuntaan liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.placed.description": "Lisätty olemassa olevaa sisältöä tähän tiedostoon",
+  "selectors.editsAndActivity.c2pa.placed.label": "Tuotu",
+  "selectors.editsAndActivity.c2pa.resized.description": "Muutettu mittasuhteita tai tiedostokokoa",
+  "selectors.editsAndActivity.c2pa.resized.label": "Koon muuttamiseen liittyvät muokkaukset",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Suoritettu muita muokkauksia tai toimintoja, joita ei tunnistettu",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Tuntemattomat muokkaukset tai tuntematon toiminta"
 }

--- a/packages/c2pa/i18n/fr-FR.json
+++ b/packages/c2pa/i18n/fr-FR.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Ajustement des propriétés, comme la tonalité, la saturation, les courbes, les ombres ou les tons clairs",
-        "label": "Modifications de la couleur ou de l’exposition"
-      },
-      "c2pa.created": {
-        "description": "Création d’un nouveau fichier ou contenu",
-        "label": "Créé"
-      },
-      "c2pa.cropped": {
-        "description": "Utilisation d’outils de recadrage, réduisant ou élargissant la zone de contenu visible",
-        "label": "Modifications de recadrage"
-      },
-      "c2pa.drawing": {
-        "description": "Utilisation d’outils, comme des crayons, des pinceaux, des gommes ou des outils de forme, de tracé ou de plume",
-        "label": "Modifications du dessin"
-      },
-      "c2pa.edited": {
-        "description": "Réalisation d’autres modifications",
-        "label": "Autres modifications"
-      },
-      "c2pa.filtered": {
-        "description": "Utilisation d’outils tels que des filtres, des styles ou des effets pour modifier l’apparence",
-        "label": "Modifications du filtre ou du style"
-      },
-      "c2pa.opened": {
-        "description": "Ouverture d’un fichier préexistant",
-        "label": "Ouvert"
-      },
-      "c2pa.orientation": {
-        "description": "Changement de position ou d’orientation (rotation, renversement, etc.)",
-        "label": "Orientation Modifications de "
-      },
-      "c2pa.placed": {
-        "description": "Ajout du contenu préexistant à ce fichier",
-        "label": "Importé"
-      },
-      "c2pa.resized": {
-        "description": "Modification des dimensions ou de la taille du fichier",
-        "label": "Modifications du redimensionnement"
-      },
-      "c2pa.unknown": {
-        "description": "Réalisation d’autres modifications ou activités qui n’ont pas pu être reconnues",
-        "label": "Modifications ou activité inconnues"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Ajustement des propriétés, comme la tonalité, la saturation, les courbes, les ombres ou les tons clairs",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Modifications de la couleur ou de l’exposition",
+  "selectors.editsAndActivity.c2pa.created.description": "Création d’un nouveau fichier ou contenu",
+  "selectors.editsAndActivity.c2pa.created.label": "Créé",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Utilisation d’outils de recadrage, réduisant ou élargissant la zone de contenu visible",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Modifications de recadrage",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Utilisation d’outils, comme des crayons, des pinceaux, des gommes ou des outils de forme, de tracé ou de plume",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Modifications du dessin",
+  "selectors.editsAndActivity.c2pa.edited.description": "Réalisation d’autres modifications",
+  "selectors.editsAndActivity.c2pa.edited.label": "Autres modifications",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Utilisation d’outils tels que des filtres, des styles ou des effets pour modifier l’apparence",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Modifications du filtre ou du style",
+  "selectors.editsAndActivity.c2pa.opened.description": "Ouverture d’un fichier préexistant",
+  "selectors.editsAndActivity.c2pa.opened.label": "Ouvert",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Changement de position ou d’orientation (rotation, renversement, etc.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientation Modifications de ",
+  "selectors.editsAndActivity.c2pa.placed.description": "Ajout du contenu préexistant à ce fichier",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importé",
+  "selectors.editsAndActivity.c2pa.resized.description": "Modification des dimensions ou de la taille du fichier",
+  "selectors.editsAndActivity.c2pa.resized.label": "Modifications du redimensionnement",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Réalisation d’autres modifications ou activités qui n’ont pas pu être reconnues",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Modifications ou activité inconnues"
 }

--- a/packages/c2pa/i18n/hu-HU.json
+++ b/packages/c2pa/i18n/hu-HU.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Beállított olyan tulajdonságokat mint árnyalat, telítettség, görbék, árnyékok vagy csúcsfények",
-        "label": "Szín vagy expozíció szerkesztése"
-      },
-      "c2pa.created": {
-        "description": "Létrehozott egy új fájlt vagy tartalmat",
-        "label": "Létrehozva"
-      },
-      "c2pa.cropped": {
-        "description": "Használt vágóeszközöket, amelyek csökkentik vagy bővítik a tartalom látható területét",
-        "label": "Vágást használó szerkesztések"
-      },
-      "c2pa.drawing": {
-        "description": "Használt olyan eszközöket mint ceruzák, ecsetek, radírok vagy alakzat-, görbe- vagy tolleszközök",
-        "label": "Rajzolást használó szerkesztések"
-      },
-      "c2pa.edited": {
-        "description": "Egyéb módosítások végrehajtva",
-        "label": "Egyéb szerkesztések"
-      },
-      "c2pa.filtered": {
-        "description": "Használt olyan eszközöket mint szűrők, stílusok vagy effektusok a megjelenés megváltoztatására",
-        "label": "Szűrőt vagy stílust használó szerkesztések"
-      },
-      "c2pa.opened": {
-        "description": "Megnyitott egy már létező fájlt",
-        "label": "Megnyitva"
-      },
-      "c2pa.orientation": {
-        "description": "Módosította a pozíciót vagy tájolást (elforgatva, megfordítva stb.)",
-        "label": "Tájolás szerkesztések"
-      },
-      "c2pa.placed": {
-        "description": "Már létező tartalmat adott hozzá ehhez a fájlhoz",
-        "label": "Importálva"
-      },
-      "c2pa.resized": {
-        "description": "A méretek vagy a fájl mérete módosult",
-        "label": "Szerkesztések átméretezése"
-      },
-      "c2pa.unknown": {
-        "description": "Más szerkesztéseket vagy műveleteket hajtott végre, amelyeket nem lehetett felismerni",
-        "label": "Ismeretlen szerkesztések vagy tevékenység"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Beállított olyan tulajdonságokat mint árnyalat, telítettség, görbék, árnyékok vagy csúcsfények",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Szín vagy expozíció szerkesztése",
+  "selectors.editsAndActivity.c2pa.created.description": "Létrehozott egy új fájlt vagy tartalmat",
+  "selectors.editsAndActivity.c2pa.created.label": "Létrehozva",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Használt vágóeszközöket, amelyek csökkentik vagy bővítik a tartalom látható területét",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Vágást használó szerkesztések",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Használt olyan eszközöket mint ceruzák, ecsetek, radírok vagy alakzat-, görbe- vagy tolleszközök",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Rajzolást használó szerkesztések",
+  "selectors.editsAndActivity.c2pa.edited.description": "Egyéb módosítások végrehajtva",
+  "selectors.editsAndActivity.c2pa.edited.label": "Egyéb szerkesztések",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Használt olyan eszközöket mint szűrők, stílusok vagy effektusok a megjelenés megváltoztatására",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Szűrőt vagy stílust használó szerkesztések",
+  "selectors.editsAndActivity.c2pa.opened.description": "Megnyitott egy már létező fájlt",
+  "selectors.editsAndActivity.c2pa.opened.label": "Megnyitva",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Módosította a pozíciót vagy tájolást (elforgatva, megfordítva stb.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Tájolás szerkesztések",
+  "selectors.editsAndActivity.c2pa.placed.description": "Már létező tartalmat adott hozzá ehhez a fájlhoz",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importálva",
+  "selectors.editsAndActivity.c2pa.resized.description": "A méretek vagy a fájl mérete módosult",
+  "selectors.editsAndActivity.c2pa.resized.label": "Szerkesztések átméretezése",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Más szerkesztéseket vagy műveleteket hajtott végre, amelyeket nem lehetett felismerni",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Ismeretlen szerkesztések vagy tevékenység"
 }

--- a/packages/c2pa/i18n/it-IT.json
+++ b/packages/c2pa/i18n/it-IT.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Proprietà regolate come tono, saturazione, curve, ombre o luci",
-        "label": "Modifiche del colore o dell'esposizione"
-      },
-      "c2pa.created": {
-        "description": "È stato creato un nuovo file o contenuto",
-        "label": "Creato"
-      },
-      "c2pa.cropped": {
-        "description": "Strumenti di ritaglio utilizzati, riducendo o espandendo l'area del contenuto visibile",
-        "label": "Modifiche di ritaglio"
-      },
-      "c2pa.drawing": {
-        "description": "Strumenti usati come matite, pennelli, gomme o strumenti forma, tracciato o penna",
-        "label": "Modifiche del disegno"
-      },
-      "c2pa.edited": {
-        "description": "Sono state apportate altre modifiche",
-        "label": "Altre modifiche"
-      },
-      "c2pa.filtered": {
-        "description": "Strumenti utilizzati come filtri, stili o effetti per modificare l'aspetto",
-        "label": "Modifiche di filtro o stile"
-      },
-      "c2pa.opened": {
-        "description": "È stato aperto un file preesistente",
-        "label": "Aperto"
-      },
-      "c2pa.orientation": {
-        "description": "Posizione o orientamento modificati (ruotati, capovolti e così via)",
-        "label": "Orientamento modifiche"
-      },
-      "c2pa.placed": {
-        "description": "Aggiunto contenuto preesistente a questo file",
-        "label": "Importato"
-      },
-      "c2pa.resized": {
-        "description": "Dimensioni o grandezza del file modificate",
-        "label": "Modifiche del ridimensionamento"
-      },
-      "c2pa.unknown": {
-        "description": "Sono state eseguite altre modifiche o attività che non è stato possibile riconoscere",
-        "label": "Modifiche o attività sconosciute"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Proprietà regolate come tono, saturazione, curve, ombre o luci",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Modifiche del colore o dell'esposizione",
+  "selectors.editsAndActivity.c2pa.created.description": "È stato creato un nuovo file o contenuto",
+  "selectors.editsAndActivity.c2pa.created.label": "Creato",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Strumenti di ritaglio utilizzati, riducendo o espandendo l'area del contenuto visibile",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Modifiche di ritaglio",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Strumenti usati come matite, pennelli, gomme o strumenti forma, tracciato o penna",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Modifiche del disegno",
+  "selectors.editsAndActivity.c2pa.edited.description": "Sono state apportate altre modifiche",
+  "selectors.editsAndActivity.c2pa.edited.label": "Altre modifiche",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Strumenti utilizzati come filtri, stili o effetti per modificare l'aspetto",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Modifiche di filtro o stile",
+  "selectors.editsAndActivity.c2pa.opened.description": "È stato aperto un file preesistente",
+  "selectors.editsAndActivity.c2pa.opened.label": "Aperto",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Posizione o orientamento modificati (ruotati, capovolti e così via)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientamento modifiche",
+  "selectors.editsAndActivity.c2pa.placed.description": "Aggiunto contenuto preesistente a questo file",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importato",
+  "selectors.editsAndActivity.c2pa.resized.description": "Dimensioni o grandezza del file modificate",
+  "selectors.editsAndActivity.c2pa.resized.label": "Modifiche del ridimensionamento",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Sono state eseguite altre modifiche o attività che non è stato possibile riconoscere",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Modifiche o attività sconosciute"
 }

--- a/packages/c2pa/i18n/ja-JP.json
+++ b/packages/c2pa/i18n/ja-JP.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "トーン、彩度、カーブ、シャドウ、ハイライトなどのプロパティを調整",
-        "label": "カラーまたは露出の編集"
-      },
-      "c2pa.created": {
-        "description": "新しいファイルまたはコンテンツを作成",
-        "label": "作成済み"
-      },
-      "c2pa.cropped": {
-        "description": "切り抜きツールを使用、表示されているコンテンツ領域の縮小または拡大",
-        "label": "切り抜きの編集"
-      },
-      "c2pa.drawing": {
-        "description": "鉛筆、ブラシ、消しゴム、シェイプ、パス、ペンツールなどのツールを使用",
-        "label": "描画の編集"
-      },
-      "c2pa.edited": {
-        "description": "その他の変更",
-        "label": "その他の編集"
-      },
-      "c2pa.filtered": {
-        "description": "フィルター、スタイル、効果などのツールを使用して外観を変更",
-        "label": "フィルターまたはスタイルの編集"
-      },
-      "c2pa.opened": {
-        "description": "既存のファイルを開いた",
-        "label": "開いた"
-      },
-      "c2pa.orientation": {
-        "description": "位置または方向を変更 (回転、反転など)",
-        "label": "画像方向編集"
-      },
-      "c2pa.placed": {
-        "description": "このファイルに既存のコンテンツを追加",
-        "label": "読み込み済み"
-      },
-      "c2pa.resized": {
-        "description": "寸法またはファイルサイズを変更",
-        "label": "サイズ変更の編集"
-      },
-      "c2pa.unknown": {
-        "description": "認識できない他の編集またはアクティビティを実行",
-        "label": "不明な編集またはアクティビティ"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "トーン、彩度、カーブ、シャドウ、ハイライトなどのプロパティを調整",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "カラーまたは露出の編集",
+  "selectors.editsAndActivity.c2pa.created.description": "新しいファイルまたはコンテンツを作成",
+  "selectors.editsAndActivity.c2pa.created.label": "作成済み",
+  "selectors.editsAndActivity.c2pa.cropped.description": "切り抜きツールを使用、表示されているコンテンツ領域の縮小または拡大",
+  "selectors.editsAndActivity.c2pa.cropped.label": "切り抜きの編集",
+  "selectors.editsAndActivity.c2pa.drawing.description": "鉛筆、ブラシ、消しゴム、シェイプ、パス、ペンツールなどのツールを使用",
+  "selectors.editsAndActivity.c2pa.drawing.label": "描画の編集",
+  "selectors.editsAndActivity.c2pa.edited.description": "その他の変更",
+  "selectors.editsAndActivity.c2pa.edited.label": "その他の編集",
+  "selectors.editsAndActivity.c2pa.filtered.description": "フィルター、スタイル、効果などのツールを使用して外観を変更",
+  "selectors.editsAndActivity.c2pa.filtered.label": "フィルターまたはスタイルの編集",
+  "selectors.editsAndActivity.c2pa.opened.description": "既存のファイルを開いた",
+  "selectors.editsAndActivity.c2pa.opened.label": "開いた",
+  "selectors.editsAndActivity.c2pa.orientation.description": "位置または方向を変更 (回転、反転など)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "画像方向編集",
+  "selectors.editsAndActivity.c2pa.placed.description": "このファイルに既存のコンテンツを追加",
+  "selectors.editsAndActivity.c2pa.placed.label": "読み込み済み",
+  "selectors.editsAndActivity.c2pa.resized.description": "寸法またはファイルサイズを変更",
+  "selectors.editsAndActivity.c2pa.resized.label": "サイズ変更の編集",
+  "selectors.editsAndActivity.c2pa.unknown.description": "認識できない他の編集またはアクティビティを実行",
+  "selectors.editsAndActivity.c2pa.unknown.label": "不明な編集またはアクティビティ"
 }

--- a/packages/c2pa/i18n/ko-KR.json
+++ b/packages/c2pa/i18n/ko-KR.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "톤, 채도, 곡선, 그림자 또는 하이라이트와 같은 조정된 속성",
-        "label": "색상 또는 노출 편집"
-      },
-      "c2pa.created": {
-        "description": "새 파일 또는 콘텐츠 생성됨",
-        "label": "생성됨"
-      },
-      "c2pa.cropped": {
-        "description": "사용된 자르기 도구, 보이는 콘텐츠 영역 축소 또는 확장",
-        "label": "자르기 편집"
-      },
-      "c2pa.drawing": {
-        "description": "연필, 브러시, 지우개 또는 모양, 경로 또는 펜 도구와 같은 사용된 도구",
-        "label": "그리기 편집"
-      },
-      "c2pa.edited": {
-        "description": "기타 변경 사항 적용됨",
-        "label": "기타 편집"
-      },
-      "c2pa.filtered": {
-        "description": "필터, 스타일 또는 효과와 같은 모양 변경에 사용된 도구",
-        "label": "필터 또는 스타일 편집"
-      },
-      "c2pa.opened": {
-        "description": "기존 파일 열림",
-        "label": "열림"
-      },
-      "c2pa.orientation": {
-        "description": "변경된 위치 또는 방향 (회전, 반전 등)",
-        "label": "방향 편집"
-      },
-      "c2pa.placed": {
-        "description": "이 파일에 기존 콘텐츠 추가됨",
-        "label": "가져옴"
-      },
-      "c2pa.resized": {
-        "description": "변경된 치수 또는 파일 크기",
-        "label": "크기 조정 편집"
-      },
-      "c2pa.unknown": {
-        "description": "수행되었으나 인식할 수 없는 기타 편집 또는 활동",
-        "label": "알 수 없는 편집 또는 활동"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "톤, 채도, 곡선, 그림자 또는 하이라이트와 같은 조정된 속성",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "색상 또는 노출 편집",
+  "selectors.editsAndActivity.c2pa.created.description": "새 파일 또는 콘텐츠 생성됨",
+  "selectors.editsAndActivity.c2pa.created.label": "생성됨",
+  "selectors.editsAndActivity.c2pa.cropped.description": "사용된 자르기 도구, 보이는 콘텐츠 영역 축소 또는 확장",
+  "selectors.editsAndActivity.c2pa.cropped.label": "자르기 편집",
+  "selectors.editsAndActivity.c2pa.drawing.description": "연필, 브러시, 지우개 또는 모양, 경로 또는 펜 도구와 같은 사용된 도구",
+  "selectors.editsAndActivity.c2pa.drawing.label": "그리기 편집",
+  "selectors.editsAndActivity.c2pa.edited.description": "기타 변경 사항 적용됨",
+  "selectors.editsAndActivity.c2pa.edited.label": "기타 편집",
+  "selectors.editsAndActivity.c2pa.filtered.description": "필터, 스타일 또는 효과와 같은 모양 변경에 사용된 도구",
+  "selectors.editsAndActivity.c2pa.filtered.label": "필터 또는 스타일 편집",
+  "selectors.editsAndActivity.c2pa.opened.description": "기존 파일 열림",
+  "selectors.editsAndActivity.c2pa.opened.label": "열림",
+  "selectors.editsAndActivity.c2pa.orientation.description": "변경된 위치 또는 방향 (회전, 반전 등)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "방향 편집",
+  "selectors.editsAndActivity.c2pa.placed.description": "이 파일에 기존 콘텐츠 추가됨",
+  "selectors.editsAndActivity.c2pa.placed.label": "가져옴",
+  "selectors.editsAndActivity.c2pa.resized.description": "변경된 치수 또는 파일 크기",
+  "selectors.editsAndActivity.c2pa.resized.label": "크기 조정 편집",
+  "selectors.editsAndActivity.c2pa.unknown.description": "수행되었으나 인식할 수 없는 기타 편집 또는 활동",
+  "selectors.editsAndActivity.c2pa.unknown.label": "알 수 없는 편집 또는 활동"
 }

--- a/packages/c2pa/i18n/nb-NO.json
+++ b/packages/c2pa/i18n/nb-NO.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Justerte egenskaper som tone, metning, kurver, skygger eller høylys",
-        "label": "Farge- eller eksponeringsredigeringer"
-      },
-      "c2pa.created": {
-        "description": "Opprettet en ny fil eller nytt innhold",
-        "label": "Opprettet"
-      },
-      "c2pa.cropped": {
-        "description": "Brukte beskjæringsverktøy for å redusere eller utvide synlig innholdsområde",
-        "label": "Beskjæringsredigeringer"
-      },
-      "c2pa.drawing": {
-        "description": "Brukte verktøy som blyanter, pensler, viskelær eller form-, bane- eller pennverktøy",
-        "label": "Tegneredigeringer"
-      },
-      "c2pa.edited": {
-        "description": "Gjorde andre endringer",
-        "label": "Andre redigeringer"
-      },
-      "c2pa.filtered": {
-        "description": "Brukte verktøy som filtre, stiler eller effekter for å endre utseende",
-        "label": "Filter- eller stilredigeringer"
-      },
-      "c2pa.opened": {
-        "description": "Åpnet en eksisterende fil",
-        "label": "Åpnet"
-      },
-      "c2pa.orientation": {
-        "description": "Endret posisjon eller retning (rotert, snudd osv.)",
-        "label": "Retnings- redigeringer"
-      },
-      "c2pa.placed": {
-        "description": "La til eksisterende innhold i denne filen",
-        "label": "Importert"
-      },
-      "c2pa.resized": {
-        "description": "Endret dimensjoner eller filstørrelse",
-        "label": "Størrelsesendringer"
-      },
-      "c2pa.unknown": {
-        "description": "Utførte andre redigeringer eller aktiviteter som ikke gjenkjennes",
-        "label": "Ukjent endring eller aktivitet"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Justerte egenskaper som tone, metning, kurver, skygger eller høylys",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Farge- eller eksponeringsredigeringer",
+  "selectors.editsAndActivity.c2pa.created.description": "Opprettet en ny fil eller nytt innhold",
+  "selectors.editsAndActivity.c2pa.created.label": "Opprettet",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Brukte beskjæringsverktøy for å redusere eller utvide synlig innholdsområde",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Beskjæringsredigeringer",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Brukte verktøy som blyanter, pensler, viskelær eller form-, bane- eller pennverktøy",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Tegneredigeringer",
+  "selectors.editsAndActivity.c2pa.edited.description": "Gjorde andre endringer",
+  "selectors.editsAndActivity.c2pa.edited.label": "Andre redigeringer",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Brukte verktøy som filtre, stiler eller effekter for å endre utseende",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Filter- eller stilredigeringer",
+  "selectors.editsAndActivity.c2pa.opened.description": "Åpnet en eksisterende fil",
+  "selectors.editsAndActivity.c2pa.opened.label": "Åpnet",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Endret posisjon eller retning (rotert, snudd osv.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Retnings- redigeringer",
+  "selectors.editsAndActivity.c2pa.placed.description": "La til eksisterende innhold i denne filen",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importert",
+  "selectors.editsAndActivity.c2pa.resized.description": "Endret dimensjoner eller filstørrelse",
+  "selectors.editsAndActivity.c2pa.resized.label": "Størrelsesendringer",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Utførte andre redigeringer eller aktiviteter som ikke gjenkjennes",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Ukjent endring eller aktivitet"
 }

--- a/packages/c2pa/i18n/nl-NL.json
+++ b/packages/c2pa/i18n/nl-NL.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Eigenschappen zoals tint, verzadiging, curven, schaduwen of hooglichten aangepast",
-        "label": "Kleur- of belichtingsbewerkingen"
-      },
-      "c2pa.created": {
-        "description": "Een nieuw bestand of content gemaakt",
-        "label": "Gemaakt"
-      },
-      "c2pa.cropped": {
-        "description": "Uitsnedegereedschappen gebruikt om het zichtbare deel van de content te beperken of uit te breiden",
-        "label": "Uitsnedebewerkingen"
-      },
-      "c2pa.drawing": {
-        "description": "Gereedschappen gebruikt zoals potloden, penselen, gummetjes, pennen of vorm- of padgereedschappen",
-        "label": "Tekenbewerkingen"
-      },
-      "c2pa.edited": {
-        "description": "Andere wijzigingen aangebracht",
-        "label": "Andere bewerkingen"
-      },
-      "c2pa.filtered": {
-        "description": "Gereedschappen zoals filters, stijlen of effecten gebruikt om het uiterlijk te veranderen",
-        "label": "Filter- of stijlbewerkingen"
-      },
-      "c2pa.opened": {
-        "description": "Een bestaand bestand geopend",
-        "label": "Geopend"
-      },
-      "c2pa.orientation": {
-        "description": "Positie of stand gewijzigd (gedraaid, gespiegeld etc.)",
-        "label": "Afdrukstand bewerkingen"
-      },
-      "c2pa.placed": {
-        "description": "Bestaande content aan dit bestand toegevoegd",
-        "label": "Geïmporteerd"
-      },
-      "c2pa.resized": {
-        "description": "Afmetingen of bestandsgrootte gewijzigd",
-        "label": "Formaatbewerkingen"
-      },
-      "c2pa.unknown": {
-        "description": "Andere bewerkingen of activiteiten uitgevoerd die niet konden worden herkend",
-        "label": "Onbekende bewerkingen of activiteiten"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Eigenschappen zoals tint, verzadiging, curven, schaduwen of hooglichten aangepast",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Kleur- of belichtingsbewerkingen",
+  "selectors.editsAndActivity.c2pa.created.description": "Een nieuw bestand of content gemaakt",
+  "selectors.editsAndActivity.c2pa.created.label": "Gemaakt",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Uitsnedegereedschappen gebruikt om het zichtbare deel van de content te beperken of uit te breiden",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Uitsnedebewerkingen",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Gereedschappen gebruikt zoals potloden, penselen, gummetjes, pennen of vorm- of padgereedschappen",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Tekenbewerkingen",
+  "selectors.editsAndActivity.c2pa.edited.description": "Andere wijzigingen aangebracht",
+  "selectors.editsAndActivity.c2pa.edited.label": "Andere bewerkingen",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Gereedschappen zoals filters, stijlen of effecten gebruikt om het uiterlijk te veranderen",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Filter- of stijlbewerkingen",
+  "selectors.editsAndActivity.c2pa.opened.description": "Een bestaand bestand geopend",
+  "selectors.editsAndActivity.c2pa.opened.label": "Geopend",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Positie of stand gewijzigd (gedraaid, gespiegeld etc.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Afdrukstand bewerkingen",
+  "selectors.editsAndActivity.c2pa.placed.description": "Bestaande content aan dit bestand toegevoegd",
+  "selectors.editsAndActivity.c2pa.placed.label": "Geïmporteerd",
+  "selectors.editsAndActivity.c2pa.resized.description": "Afmetingen of bestandsgrootte gewijzigd",
+  "selectors.editsAndActivity.c2pa.resized.label": "Formaatbewerkingen",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Andere bewerkingen of activiteiten uitgevoerd die niet konden worden herkend",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Onbekende bewerkingen of activiteiten"
 }

--- a/packages/c2pa/i18n/pl-PL.json
+++ b/packages/c2pa/i18n/pl-PL.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Zmodyfikowano właściwości, takie jak tonacja, nasycenie, krzywe, cienie lub światła",
-        "label": "Wprowadzono zmiany kolorów lub ekspozycji"
-      },
-      "c2pa.created": {
-        "description": "Utworzono nowy plik lub zawartość",
-        "label": "Utworzono"
-      },
-      "c2pa.cropped": {
-        "description": "Użyto narzędzi do kadrowania w celu zmniejszenia lub rozszerzenia widocznego obszaru zawartości",
-        "label": "Modyfikacje polegające na kadrowaniu"
-      },
-      "c2pa.drawing": {
-        "description": "Użyto takich narzędzi, jak ołówki, pędzle i gumki albo narzędzi kształtów, ścieżek lub pióra",
-        "label": "Modyfikacje rysunkowe"
-      },
-      "c2pa.edited": {
-        "description": "Wprowadzono inne zmiany",
-        "label": "Inne modyfikacje"
-      },
-      "c2pa.filtered": {
-        "description": "Użyto narzędzi, takich jak filtry, style lub efekty, aby zmienić wygląd",
-        "label": "Edycje filtrów lub stylów"
-      },
-      "c2pa.opened": {
-        "description": "Otwarto wcześniej istniejący plik",
-        "label": "Otwarto"
-      },
-      "c2pa.orientation": {
-        "description": "Zmieniono pozycję lub orientację (obrócono, odwrócono itp.)",
-        "label": "Orientacja modyfikacje"
-      },
-      "c2pa.placed": {
-        "description": "Dodano wcześniej istniejącą zawartość do tego pliku",
-        "label": "Zaimportowano"
-      },
-      "c2pa.resized": {
-        "description": "Zmieniono wymiary lub rozmiar pliku",
-        "label": "Modyfikacje polegające na zmianie rozmiaru"
-      },
-      "c2pa.unknown": {
-        "description": "Dokonano innych zmian lub wykonano operacje, których nie można rozpoznać",
-        "label": "Nieznane zmiany lub operacje"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Zmodyfikowano właściwości, takie jak tonacja, nasycenie, krzywe, cienie lub światła",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Wprowadzono zmiany kolorów lub ekspozycji",
+  "selectors.editsAndActivity.c2pa.created.description": "Utworzono nowy plik lub zawartość",
+  "selectors.editsAndActivity.c2pa.created.label": "Utworzono",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Użyto narzędzi do kadrowania w celu zmniejszenia lub rozszerzenia widocznego obszaru zawartości",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Modyfikacje polegające na kadrowaniu",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Użyto takich narzędzi, jak ołówki, pędzle i gumki albo narzędzi kształtów, ścieżek lub pióra",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Modyfikacje rysunkowe",
+  "selectors.editsAndActivity.c2pa.edited.description": "Wprowadzono inne zmiany",
+  "selectors.editsAndActivity.c2pa.edited.label": "Inne modyfikacje",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Użyto narzędzi, takich jak filtry, style lub efekty, aby zmienić wygląd",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Edycje filtrów lub stylów",
+  "selectors.editsAndActivity.c2pa.opened.description": "Otwarto wcześniej istniejący plik",
+  "selectors.editsAndActivity.c2pa.opened.label": "Otwarto",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Zmieniono pozycję lub orientację (obrócono, odwrócono itp.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientacja modyfikacje",
+  "selectors.editsAndActivity.c2pa.placed.description": "Dodano wcześniej istniejącą zawartość do tego pliku",
+  "selectors.editsAndActivity.c2pa.placed.label": "Zaimportowano",
+  "selectors.editsAndActivity.c2pa.resized.description": "Zmieniono wymiary lub rozmiar pliku",
+  "selectors.editsAndActivity.c2pa.resized.label": "Modyfikacje polegające na zmianie rozmiaru",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Dokonano innych zmian lub wykonano operacje, których nie można rozpoznać",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Nieznane zmiany lub operacje"
 }

--- a/packages/c2pa/i18n/pt-BR.json
+++ b/packages/c2pa/i18n/pt-BR.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Propriedades como tom, saturação, curvas, sombras ou realces ajustadas",
-        "label": "Edições de cor ou exposição"
-      },
-      "c2pa.created": {
-        "description": "Arquivo ou conteúdo criado",
-        "label": "Criado"
-      },
-      "c2pa.cropped": {
-        "description": "Ferramentas de corte usadas, reduzindo ou expandindo a área de conteúdo visível",
-        "label": "Edições de corte"
-      },
-      "c2pa.drawing": {
-        "description": "Ferramentas como lápis, pincéis, borrachas ou ferramentas de forma, caminho ou caneta usadas",
-        "label": "Edições de desenho"
-      },
-      "c2pa.edited": {
-        "description": "Outras alterações feitas",
-        "label": "Outras edições"
-      },
-      "c2pa.filtered": {
-        "description": "Ferramentas como filtros, estilos ou efeitos usadas para alterar a aparência",
-        "label": "Edições de filtro ou estilo"
-      },
-      "c2pa.opened": {
-        "description": "Arquivo pré-existente aberto",
-        "label": "Aberto"
-      },
-      "c2pa.orientation": {
-        "description": "Posição ou orientação alterada (girado, invertido etc.)",
-        "label": "Edições de orientação"
-      },
-      "c2pa.placed": {
-        "description": "Conteúdo pré-existente adicionado a este arquivo",
-        "label": "Importado"
-      },
-      "c2pa.resized": {
-        "description": "Dimensões ou tamanho do arquivo alterados",
-        "label": "Edições de redimensionamento"
-      },
-      "c2pa.unknown": {
-        "description": "Não foi possível reconhecer outras edições ou atividades realizadas",
-        "label": "Edições ou atividades desconhecidas"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Propriedades como tom, saturação, curvas, sombras ou realces ajustadas",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Edições de cor ou exposição",
+  "selectors.editsAndActivity.c2pa.created.description": "Arquivo ou conteúdo criado",
+  "selectors.editsAndActivity.c2pa.created.label": "Criado",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Ferramentas de corte usadas, reduzindo ou expandindo a área de conteúdo visível",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Edições de corte",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Ferramentas como lápis, pincéis, borrachas ou ferramentas de forma, caminho ou caneta usadas",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Edições de desenho",
+  "selectors.editsAndActivity.c2pa.edited.description": "Outras alterações feitas",
+  "selectors.editsAndActivity.c2pa.edited.label": "Outras edições",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Ferramentas como filtros, estilos ou efeitos usadas para alterar a aparência",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Edições de filtro ou estilo",
+  "selectors.editsAndActivity.c2pa.opened.description": "Arquivo pré-existente aberto",
+  "selectors.editsAndActivity.c2pa.opened.label": "Aberto",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Posição ou orientação alterada (girado, invertido etc.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Edições de orientação",
+  "selectors.editsAndActivity.c2pa.placed.description": "Conteúdo pré-existente adicionado a este arquivo",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importado",
+  "selectors.editsAndActivity.c2pa.resized.description": "Dimensões ou tamanho do arquivo alterados",
+  "selectors.editsAndActivity.c2pa.resized.label": "Edições de redimensionamento",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Não foi possível reconhecer outras edições ou atividades realizadas",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Edições ou atividades desconhecidas"
 }

--- a/packages/c2pa/i18n/ru-RU.json
+++ b/packages/c2pa/i18n/ru-RU.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Измененные свойства, например тон, насыщенность, кривые, тени или блики.",
-        "label": "Редактирование цвета или экспозиции"
-      },
-      "c2pa.created": {
-        "description": "Создан новый файл или контент",
-        "label": "Создано"
-      },
-      "c2pa.cropped": {
-        "description": "Используемые инструменты обрезки, уменьшение или расширение видимой области содержимого",
-        "label": "Редактирование обрезки"
-      },
-      "c2pa.drawing": {
-        "description": "Используемые инструменты, например карандаши, кисти, ластики или другие инструменты (форма, контур или перо)",
-        "label": "Редактирование чертежа"
-      },
-      "c2pa.edited": {
-        "description": "Внесены другие изменения",
-        "label": "Другие изменения"
-      },
-      "c2pa.filtered": {
-        "description": "Используемые инструменты для изменения внешнего вида, например фильтры, стили или эффекты",
-        "label": "Редактирование фильтров или стилей"
-      },
-      "c2pa.opened": {
-        "description": "Открыт ранее созданный файл",
-        "label": "Открыто"
-      },
-      "c2pa.orientation": {
-        "description": "Изменено положение или ориентация (повернуто, перевернуто и т. д.)",
-        "label": "Ориентация правки"
-      },
-      "c2pa.placed": {
-        "description": "В этот файл добавлен уже существующий контент",
-        "label": "Импортировано"
-      },
-      "c2pa.resized": {
-        "description": "Изменены размеры изображения или размер файла",
-        "label": "Изменение размеров"
-      },
-      "c2pa.unknown": {
-        "description": "Внесены другие правки или выполнены иные действия, которые не удалось распознать",
-        "label": "Неизвестные изменения или действия"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Измененные свойства, например тон, насыщенность, кривые, тени или блики.",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Редактирование цвета или экспозиции",
+  "selectors.editsAndActivity.c2pa.created.description": "Создан новый файл или контент",
+  "selectors.editsAndActivity.c2pa.created.label": "Создано",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Используемые инструменты обрезки, уменьшение или расширение видимой области содержимого",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Редактирование обрезки",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Используемые инструменты, например карандаши, кисти, ластики или другие инструменты (форма, контур или перо)",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Редактирование чертежа",
+  "selectors.editsAndActivity.c2pa.edited.description": "Внесены другие изменения",
+  "selectors.editsAndActivity.c2pa.edited.label": "Другие изменения",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Используемые инструменты для изменения внешнего вида, например фильтры, стили или эффекты",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Редактирование фильтров или стилей",
+  "selectors.editsAndActivity.c2pa.opened.description": "Открыт ранее созданный файл",
+  "selectors.editsAndActivity.c2pa.opened.label": "Открыто",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Изменено положение или ориентация (повернуто, перевернуто и т. д.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Ориентация правки",
+  "selectors.editsAndActivity.c2pa.placed.description": "В этот файл добавлен уже существующий контент",
+  "selectors.editsAndActivity.c2pa.placed.label": "Импортировано",
+  "selectors.editsAndActivity.c2pa.resized.description": "Изменены размеры изображения или размер файла",
+  "selectors.editsAndActivity.c2pa.resized.label": "Изменение размеров",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Внесены другие правки или выполнены иные действия, которые не удалось распознать",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Неизвестные изменения или действия"
 }

--- a/packages/c2pa/i18n/sv-SE.json
+++ b/packages/c2pa/i18n/sv-SE.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Justerade egenskaper som ton, mättnad, kurvor, skuggor och högdagrar",
-        "label": "Redigering av färg eller exponering"
-      },
-      "c2pa.created": {
-        "description": "Skapade en ny fil eller nytt innehåll",
-        "label": "Skapade"
-      },
-      "c2pa.cropped": {
-        "description": "Använde beskärningsverktyg, minskade eller utökade synligt innehållsområde",
-        "label": "Redigering av beskärning"
-      },
-      "c2pa.drawing": {
-        "description": "Använde verktyg som pennor, penslar, suddgummin eller verktygen form, bana eller penna",
-        "label": "Redigering av teckning"
-      },
-      "c2pa.edited": {
-        "description": "Gjorde andra ändringar",
-        "label": "Annan redigering"
-      },
-      "c2pa.filtered": {
-        "description": "Använde verktyg som filter, stilar eller effekter för att ändra utseende",
-        "label": "Redigering av filter eller stil"
-      },
-      "c2pa.opened": {
-        "description": "Öppnade en befintlig fil",
-        "label": "Öppnade"
-      },
-      "c2pa.orientation": {
-        "description": "Ändrade placering eller orientering (roterad, vänd osv.)",
-        "label": "Orientering redigering"
-      },
-      "c2pa.placed": {
-        "description": "Lade till befintligt innehåll i den här filen",
-        "label": "Importerade"
-      },
-      "c2pa.resized": {
-        "description": "Ändrade mått eller filstorlek",
-        "label": "Redigering av storleksändring"
-      },
-      "c2pa.unknown": {
-        "description": "Utförde andra redigeringar eller aktiviteter som inte kunde identifieras",
-        "label": "Okänd redigering eller aktivitet"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Justerade egenskaper som ton, mättnad, kurvor, skuggor och högdagrar",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Redigering av färg eller exponering",
+  "selectors.editsAndActivity.c2pa.created.description": "Skapade en ny fil eller nytt innehåll",
+  "selectors.editsAndActivity.c2pa.created.label": "Skapade",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Använde beskärningsverktyg, minskade eller utökade synligt innehållsområde",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Redigering av beskärning",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Använde verktyg som pennor, penslar, suddgummin eller verktygen form, bana eller penna",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Redigering av teckning",
+  "selectors.editsAndActivity.c2pa.edited.description": "Gjorde andra ändringar",
+  "selectors.editsAndActivity.c2pa.edited.label": "Annan redigering",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Använde verktyg som filter, stilar eller effekter för att ändra utseende",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Redigering av filter eller stil",
+  "selectors.editsAndActivity.c2pa.opened.description": "Öppnade en befintlig fil",
+  "selectors.editsAndActivity.c2pa.opened.label": "Öppnade",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Ändrade placering eller orientering (roterad, vänd osv.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Orientering redigering",
+  "selectors.editsAndActivity.c2pa.placed.description": "Lade till befintligt innehåll i den här filen",
+  "selectors.editsAndActivity.c2pa.placed.label": "Importerade",
+  "selectors.editsAndActivity.c2pa.resized.description": "Ändrade mått eller filstorlek",
+  "selectors.editsAndActivity.c2pa.resized.label": "Redigering av storleksändring",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Utförde andra redigeringar eller aktiviteter som inte kunde identifieras",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Okänd redigering eller aktivitet"
 }

--- a/packages/c2pa/i18n/tr-TR.json
+++ b/packages/c2pa/i18n/tr-TR.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Ton, doygunluk, eğriler, gölgeler veya vurgular gibi ayarlanmış özellikler",
-        "label": "Renk veya pozlama düzenlemeleri"
-      },
-      "c2pa.created": {
-        "description": "Yeni bir dosya veya içerik oluşturuldu",
-        "label": "Oluşturuldu"
-      },
-      "c2pa.cropped": {
-        "description": "Kırpma araçları kullanılarak görünür içerik alanı küçültüldü veya genişletildi",
-        "label": "Kırpma düzenlemeleri"
-      },
-      "c2pa.drawing": {
-        "description": "Kurşun kalem, fırça, silgi veya şekil, yol ya da kalem araçları gibi araçlar kullanıldı",
-        "label": "Çizim düzenlemeleri"
-      },
-      "c2pa.edited": {
-        "description": "Diğer değişiklikler yapıldı",
-        "label": "Diğer düzenlemeler"
-      },
-      "c2pa.filtered": {
-        "description": "Görünümü değiştirmek için filtre, stil veya efekt gibi araçlar kullanıldı",
-        "label": "Filtre veya stil düzenlemeleri"
-      },
-      "c2pa.opened": {
-        "description": "Mevcut bir dosya açıldı",
-        "label": "Açıldı"
-      },
-      "c2pa.orientation": {
-        "description": "Konum veya yönlendirme değiştirildi (döndürüldü, ters çevrildi vb.)",
-        "label": "Yönlendirme düzenlemeleri"
-      },
-      "c2pa.placed": {
-        "description": "Mevcut içerik bu dosyaya eklendi",
-        "label": "İçe aktarıldı"
-      },
-      "c2pa.resized": {
-        "description": "Boyutlar veya dosya boyutu değiştirildi",
-        "label": "Yeniden boyutlandırma düzenlemeleri"
-      },
-      "c2pa.unknown": {
-        "description": "Algılanamayan başka düzenlemeler veya etkinlikler gerçekleştirildi",
-        "label": "Bilinmeyen düzenlemeler veya etkinlikler"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Ton, doygunluk, eğriler, gölgeler veya vurgular gibi ayarlanmış özellikler",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Renk veya pozlama düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.created.description": "Yeni bir dosya veya içerik oluşturuldu",
+  "selectors.editsAndActivity.c2pa.created.label": "Oluşturuldu",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Kırpma araçları kullanılarak görünür içerik alanı küçültüldü veya genişletildi",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Kırpma düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Kurşun kalem, fırça, silgi veya şekil, yol ya da kalem araçları gibi araçlar kullanıldı",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Çizim düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.edited.description": "Diğer değişiklikler yapıldı",
+  "selectors.editsAndActivity.c2pa.edited.label": "Diğer düzenlemeler",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Görünümü değiştirmek için filtre, stil veya efekt gibi araçlar kullanıldı",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Filtre veya stil düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.opened.description": "Mevcut bir dosya açıldı",
+  "selectors.editsAndActivity.c2pa.opened.label": "Açıldı",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Konum veya yönlendirme değiştirildi (döndürüldü, ters çevrildi vb.)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Yönlendirme düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.placed.description": "Mevcut içerik bu dosyaya eklendi",
+  "selectors.editsAndActivity.c2pa.placed.label": "İçe aktarıldı",
+  "selectors.editsAndActivity.c2pa.resized.description": "Boyutlar veya dosya boyutu değiştirildi",
+  "selectors.editsAndActivity.c2pa.resized.label": "Yeniden boyutlandırma düzenlemeleri",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Algılanamayan başka düzenlemeler veya etkinlikler gerçekleştirildi",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Bilinmeyen düzenlemeler veya etkinlikler"
 }

--- a/packages/c2pa/i18n/uk-UA.json
+++ b/packages/c2pa/i18n/uk-UA.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "Скориговано властивості, як-от тон, насиченість, криві, тіні або підсвічування",
-        "label": "Зміни кольору або експозиції"
-      },
-      "c2pa.created": {
-        "description": "Створено новий файл або вміст",
-        "label": "Створено"
-      },
-      "c2pa.cropped": {
-        "description": "Використано інструменти кадрування, зменшення або розширення області видимого вмісту",
-        "label": "Зміни кадрування"
-      },
-      "c2pa.drawing": {
-        "description": "Використано інструменти, як-от олівці, пензлі, гумки, або інструменти для форм, контурів або пера",
-        "label": "Зміни малювання"
-      },
-      "c2pa.edited": {
-        "description": "Внесено інші зміни",
-        "label": "Інші зміни"
-      },
-      "c2pa.filtered": {
-        "description": "Використано інструменти, як-от фільтри, стилі чи ефекти для зміни вигляду",
-        "label": "Зміни фільтру або стилю"
-      },
-      "c2pa.opened": {
-        "description": "Відкрито вже існуючий файл",
-        "label": "Відкрито"
-      },
-      "c2pa.orientation": {
-        "description": "Змінено положення або орієнтація (повернуто, віддзеркалено тощо)",
-        "label": "Зміни орієнтації"
-      },
-      "c2pa.placed": {
-        "description": "Додано вже існуючий вміст до цього файлу",
-        "label": "Імпортовано"
-      },
-      "c2pa.resized": {
-        "description": "Змінено геометричні розміри або розмір файлу",
-        "label": "Зміни розміру"
-      },
-      "c2pa.unknown": {
-        "description": "Виконано інші зміни або дії, які не вдалося розпізнати",
-        "label": "Невідомі зміни чи дії"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "Скориговано властивості, як-от тон, насиченість, криві, тіні або підсвічування",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "Зміни кольору або експозиції",
+  "selectors.editsAndActivity.c2pa.created.description": "Створено новий файл або вміст",
+  "selectors.editsAndActivity.c2pa.created.label": "Створено",
+  "selectors.editsAndActivity.c2pa.cropped.description": "Використано інструменти кадрування, зменшення або розширення області видимого вмісту",
+  "selectors.editsAndActivity.c2pa.cropped.label": "Зміни кадрування",
+  "selectors.editsAndActivity.c2pa.drawing.description": "Використано інструменти, як-от олівці, пензлі, гумки, або інструменти для форм, контурів або пера",
+  "selectors.editsAndActivity.c2pa.drawing.label": "Зміни малювання",
+  "selectors.editsAndActivity.c2pa.edited.description": "Внесено інші зміни",
+  "selectors.editsAndActivity.c2pa.edited.label": "Інші зміни",
+  "selectors.editsAndActivity.c2pa.filtered.description": "Використано інструменти, як-от фільтри, стилі чи ефекти для зміни вигляду",
+  "selectors.editsAndActivity.c2pa.filtered.label": "Зміни фільтру або стилю",
+  "selectors.editsAndActivity.c2pa.opened.description": "Відкрито вже існуючий файл",
+  "selectors.editsAndActivity.c2pa.opened.label": "Відкрито",
+  "selectors.editsAndActivity.c2pa.orientation.description": "Змінено положення або орієнтація (повернуто, віддзеркалено тощо)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "Зміни орієнтації",
+  "selectors.editsAndActivity.c2pa.placed.description": "Додано вже існуючий вміст до цього файлу",
+  "selectors.editsAndActivity.c2pa.placed.label": "Імпортовано",
+  "selectors.editsAndActivity.c2pa.resized.description": "Змінено геометричні розміри або розмір файлу",
+  "selectors.editsAndActivity.c2pa.resized.label": "Зміни розміру",
+  "selectors.editsAndActivity.c2pa.unknown.description": "Виконано інші зміни або дії, які не вдалося розпізнати",
+  "selectors.editsAndActivity.c2pa.unknown.label": "Невідомі зміни чи дії"
 }

--- a/packages/c2pa/i18n/zh-CN.json
+++ b/packages/c2pa/i18n/zh-CN.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "调整后的属性，如色调、饱和度、曲线、阴影或高光",
-        "label": "颜色或曝光度编辑"
-      },
-      "c2pa.created": {
-        "description": "已创建新文件或内容",
-        "label": "已创建"
-      },
-      "c2pa.cropped": {
-        "description": "已使用的裁切工具（用于减少或扩大可见内容区域）",
-        "label": "裁切编辑"
-      },
-      "c2pa.drawing": {
-        "description": "已使用的工具，如铅笔、画笔、橡皮擦、形状、路径或钢笔工具",
-        "label": "绘图编辑"
-      },
-      "c2pa.edited": {
-        "description": "已执行其他更改",
-        "label": "其他编辑"
-      },
-      "c2pa.filtered": {
-        "description": "已使用滤镜、样式或效果等工具来更改外观",
-        "label": "滤镜或样式编辑"
-      },
-      "c2pa.opened": {
-        "description": "已打开一个预先存在的文件",
-        "label": "已打开"
-      },
-      "c2pa.orientation": {
-        "description": "已改变位置或方向（旋转、翻转等）",
-        "label": "方向 编辑"
-      },
-      "c2pa.placed": {
-        "description": "已向此文件添加预先存在的内容",
-        "label": "已导入"
-      },
-      "c2pa.resized": {
-        "description": "已更改尺寸或文件大小",
-        "label": "调整编辑大小"
-      },
-      "c2pa.unknown": {
-        "description": "已执行其他无法识别的编辑或活动",
-        "label": "未知的编辑或活动"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "调整后的属性，如色调、饱和度、曲线、阴影或高光",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "颜色或曝光度编辑",
+  "selectors.editsAndActivity.c2pa.created.description": "已创建新文件或内容",
+  "selectors.editsAndActivity.c2pa.created.label": "已创建",
+  "selectors.editsAndActivity.c2pa.cropped.description": "已使用的裁切工具（用于减少或扩大可见内容区域）",
+  "selectors.editsAndActivity.c2pa.cropped.label": "裁切编辑",
+  "selectors.editsAndActivity.c2pa.drawing.description": "已使用的工具，如铅笔、画笔、橡皮擦、形状、路径或钢笔工具",
+  "selectors.editsAndActivity.c2pa.drawing.label": "绘图编辑",
+  "selectors.editsAndActivity.c2pa.edited.description": "已执行其他更改",
+  "selectors.editsAndActivity.c2pa.edited.label": "其他编辑",
+  "selectors.editsAndActivity.c2pa.filtered.description": "已使用滤镜、样式或效果等工具来更改外观",
+  "selectors.editsAndActivity.c2pa.filtered.label": "滤镜或样式编辑",
+  "selectors.editsAndActivity.c2pa.opened.description": "已打开一个预先存在的文件",
+  "selectors.editsAndActivity.c2pa.opened.label": "已打开",
+  "selectors.editsAndActivity.c2pa.orientation.description": "已改变位置或方向（旋转、翻转等）",
+  "selectors.editsAndActivity.c2pa.orientation.label": "方向 编辑",
+  "selectors.editsAndActivity.c2pa.placed.description": "已向此文件添加预先存在的内容",
+  "selectors.editsAndActivity.c2pa.placed.label": "已导入",
+  "selectors.editsAndActivity.c2pa.resized.description": "已更改尺寸或文件大小",
+  "selectors.editsAndActivity.c2pa.resized.label": "调整编辑大小",
+  "selectors.editsAndActivity.c2pa.unknown.description": "已执行其他无法识别的编辑或活动",
+  "selectors.editsAndActivity.c2pa.unknown.label": "未知的编辑或活动"
 }

--- a/packages/c2pa/i18n/zh-TW.json
+++ b/packages/c2pa/i18n/zh-TW.json
@@ -1,50 +1,24 @@
 {
-  "selectors": {
-    "editsAndActivity": {
-      "c2pa.color_adjustments": {
-        "description": "調整了屬性，如色調、飽和度、曲線、陰影或亮部",
-        "label": "顏色或曝光編輯"
-      },
-      "c2pa.created": {
-        "description": "建立了新檔案或內容",
-        "label": "已建立"
-      },
-      "c2pa.cropped": {
-        "description": "使用了裁切工具，縮減或擴大可見內容區域",
-        "label": "裁切編輯"
-      },
-      "c2pa.drawing": {
-        "description": "使用了鉛筆、筆刷、橡皮擦等工具，或是形狀、路徑或鋼筆工具",
-        "label": "繪圖編輯"
-      },
-      "c2pa.edited": {
-        "description": "進行了其他變更",
-        "label": "其他編輯"
-      },
-      "c2pa.filtered": {
-        "description": "使用了濾鏡、風格或效果等工具來變更外觀",
-        "label": "濾鏡或風格編輯"
-      },
-      "c2pa.opened": {
-        "description": "開啟了已存在的檔案",
-        "label": "已開啟"
-      },
-      "c2pa.orientation": {
-        "description": "變更了位置或方向 (旋轉、翻轉等)",
-        "label": "方向編輯"
-      },
-      "c2pa.placed": {
-        "description": "對此檔案新增了已存在的內容",
-        "label": "已讀入"
-      },
-      "c2pa.resized": {
-        "description": "變更了尺寸或檔案大小",
-        "label": "調整大小編輯"
-      },
-      "c2pa.unknown": {
-        "description": "執行了其他無法辨識的編輯或活動",
-        "label": "未知的編輯或活動"
-      }
-    }
-  }
+  "selectors.editsAndActivity.c2pa.color_adjustments.description": "調整了屬性，如色調、飽和度、曲線、陰影或亮部",
+  "selectors.editsAndActivity.c2pa.color_adjustments.label": "顏色或曝光編輯",
+  "selectors.editsAndActivity.c2pa.created.description": "建立了新檔案或內容",
+  "selectors.editsAndActivity.c2pa.created.label": "已建立",
+  "selectors.editsAndActivity.c2pa.cropped.description": "使用了裁切工具，縮減或擴大可見內容區域",
+  "selectors.editsAndActivity.c2pa.cropped.label": "裁切編輯",
+  "selectors.editsAndActivity.c2pa.drawing.description": "使用了鉛筆、筆刷、橡皮擦等工具，或是形狀、路徑或鋼筆工具",
+  "selectors.editsAndActivity.c2pa.drawing.label": "繪圖編輯",
+  "selectors.editsAndActivity.c2pa.edited.description": "進行了其他變更",
+  "selectors.editsAndActivity.c2pa.edited.label": "其他編輯",
+  "selectors.editsAndActivity.c2pa.filtered.description": "使用了濾鏡、風格或效果等工具來變更外觀",
+  "selectors.editsAndActivity.c2pa.filtered.label": "濾鏡或風格編輯",
+  "selectors.editsAndActivity.c2pa.opened.description": "開啟了已存在的檔案",
+  "selectors.editsAndActivity.c2pa.opened.label": "已開啟",
+  "selectors.editsAndActivity.c2pa.orientation.description": "變更了位置或方向 (旋轉、翻轉等)",
+  "selectors.editsAndActivity.c2pa.orientation.label": "方向編輯",
+  "selectors.editsAndActivity.c2pa.placed.description": "對此檔案新增了已存在的內容",
+  "selectors.editsAndActivity.c2pa.placed.label": "已讀入",
+  "selectors.editsAndActivity.c2pa.resized.description": "變更了尺寸或檔案大小",
+  "selectors.editsAndActivity.c2pa.resized.label": "調整大小編輯",
+  "selectors.editsAndActivity.c2pa.unknown.description": "執行了其他無法辨識的編輯或活動",
+  "selectors.editsAndActivity.c2pa.unknown.label": "未知的編輯或活動"
 }


### PR DESCRIPTION
## Changes in this pull request
- Flattens our translation files in `c2pa` to make the compatible with ALF
- Copies our translations into `c2pa-wc` so that we can start translating them via ALF before replacing the current `.str.json` files

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
