### PR TITLE
add additional check for softwareAgent

### DIFF
--- a/packages/c2pa/src/selectors/selectGenerativeInfo.ts
+++ b/packages/c2pa/src/selectors/selectGenerativeInfo.ts
@@ -150,6 +150,12 @@ export function selectGenerativeSoftwareAgents(
       }),
     ),
   ];
+
+  //if there are no software agents, return null
+  if (softwareAgents.length === 1 && Object.keys(softwareAgents[0]).length === 0) {
+    return null;
+  }
+
   //if there are undefined software agents remove them from the array
 
   return softwareAgents.filter((element) => typeof element !== 'undefined');


### PR DESCRIPTION
## Changes in this pull request
I add an extra condition in the selectGenerativeSoftwareAgents, when the object is empty (because the field softwareAgent is not in the manifest) we return null and it prevents the display of the string: '[object Object]' 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment

Link to the issue I posted: 
https://github.com/contentauth/c2pa-js/issues/186
