### PR TITLE
feat(workflow): Syncing closing associated JIRA when closing GH Issue

### DIFF
--- a/.github/workflows/closing-ticket.yml
+++ b/.github/workflows/closing-ticket.yml
@@ -1,0 +1,15 @@
+name: closing-ticket
+on:
+  issues:
+    types: [closed]
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "status: done" --remove-label "status: wip,status: todo,status: in progress,status: in test,status: not prioritized,status: blocked,status: api review,status: code review,status: design review,status: code complete,status: ready"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
Issue: CAI-6892



## Changes in this pull request
I don't know that there's a way to actually test this without merging and seeing what happens. The intent is that closing a ticket will remove all existing status labels, and add the done label which will trigger a jira sync. I tested the gh command itself and know that it's valid.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
