### PR TITLE
fix(workflow): Adding quotes around YML

### DIFF
--- a/.github/workflows/closing-ticket.yml
+++ b/.github/workflows/closing-ticket.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - run: gh issue edit "$NUMBER" --add-label "status: done" --remove-label "status: wip,status: todo,status: in progress,status: in test,status: not prioritized,status: blocked,status: api review,status: code review,status: design review,status: code complete,status: ready"
+      - run: 'gh issue edit "$NUMBER" --add-label "status: done" --remove-label "status: wip,status: todo,status: in progress,status: in test,status: not prioritized,status: blocked,status: api review,status: code review,status: design review,status: code complete,status: ready"'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Changes in this pull request
It appears that if you have a colon in YML, followed by a space, even when quoted, it will fail validation.

See https://github.com/ansible/ansible/issues/2769 for another person experiencing similar issue.

![image](https://github.com/user-attachments/assets/8ce5a434-a037-43fc-9fe3-017c91b38fe7)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
