### PR TITLE
feat(workflow): Adding label updates when reopening ticket

### DIFF
--- a/.github/workflows/reopening-ticket.yml
+++ b/.github/workflows/reopening-ticket.yml
@@ -1,0 +1,15 @@
+name: reopening-ticket
+on:
+  issues:
+    types: [reopened]
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: 'gh issue edit "$NUMBER" --add-label "status: todo" --remove-label "status: wip,status: done,status: in progress,status: in test,status: not prioritized,status: blocked,status: api review,status: code review,status: design review,status: code complete,status: ready"'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Changes in this pull request
Re-opening a ticket swaps its status labels

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
