### PR TITLE
chore: Syncing ticket status based on labels

### DIFF
--- a/.github/workflows/labeling-ticket-done.yml
+++ b/.github/workflows/labeling-ticket-done.yml
@@ -1,0 +1,17 @@
+name: labeling-ticket-done
+on:
+  issues:
+    types: [labeled]
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.issue.labels.*.name, 'status: done')
+    permissions:
+      issues: write
+    steps:
+      - run: 'gh issue close "$NUMBER"'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/name: labeling-ticket-todo.yaml
+++ b/.github/workflows/name: labeling-ticket-todo.yaml
@@ -1,0 +1,17 @@
+name: labeling-ticket-todo
+on:
+  issues:
+    types: [labeled]
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.issue.labels.*.name, 'status: todo')
+    permissions:
+      issues: write
+    steps:
+      - run: 'gh issue reopen "$NUMBER"'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Changes in this pull request
Ensuring that if JIRA updates the label, the issue will appropriately open/close.

Basing the YML on https://stackoverflow.com/questions/59588605/how-to-check-for-a-label-in-a-github-action-condition

I can't seem to find the actual docs for `contains` but see an example in other docs for actions: 

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-on-specific-branches

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
