### PR TITLE
chore: Will re-open ticket for any non-done status label

### DIFF
--- a/.github/workflows/name: labeling-ticket-todo.yaml
+++ b/.github/workflows/name: labeling-ticket-todo.yaml
@@ -6,7 +6,7 @@ jobs:
   label_issues:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.issue.labels.*.name, 'status: todo')
+      !contains(github.event.issue.labels.*.name, 'status: done')
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Changes in this pull request
Ensure any non-done label will re-open instead of just "to do"

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
