### PR TITLE
Fix optionality of CreativeWorkAssertion.author

### DIFF
--- a/packages/toolkit/types/index.ts
+++ b/packages/toolkit/types/index.ts
@@ -129,7 +129,7 @@ export type CreativeWorkAssertion = Assertion<
   {
     '@context': string;
     '@type': string;
-    author: Author[];
+    author?: Author[];
     url?: string;
   }
 >;


### PR DESCRIPTION
## Changes in this pull request
It turns out that `author` can sometimes be undefined. I just observed this in production with [this image](https://nypost.com/wp-content/uploads/sites/2/2024/06/AdobeStock_216634318.jpeg)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
