### PR TITLE
fix(cai-manifest-summary): Add disabled state to inspect button when no URL is present

### DIFF
--- a/common/changes/c2pa-wc/cai-6813-6855_2025-01-29-22-54.json
+++ b/common/changes/c2pa-wc/cai-6813-6855_2025-01-29-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa-wc",
+      "comment": "Add disable state to inspect button in cai-manifest-sumamry",
+      "type": "patch"
+    }
+  ],
+  "packageName": "c2pa-wc"
+}

--- a/packages/c2pa-wc/src/components/ManifestSummary/ManifestSummary.ts
+++ b/packages/c2pa-wc/src/components/ManifestSummary/ManifestSummary.ts
@@ -140,6 +140,22 @@ export class ManifestSummary extends Configurable(
           background-color: var(--cai-button-color);
         }
 
+        #view-more-disabled {
+          display: block;
+          transition: all 150ms ease-in-out;
+          background-color: transparent;
+          border-radius: 9999px;
+          border: 2px solid var(--cai-background-pill);
+          padding: 8px 0;
+          font-weight: bold;
+          text-align: center;
+          text-decoration: none;
+          width: 100%;
+          color: var(--cai-primary-color);
+          background-color: var(--cai-background-pill);
+          pointer-events: none;
+        }
+
         .empty {
           display: none;
         }
@@ -279,7 +295,16 @@ export class ManifestSummary extends Configurable(
                 ${this.strings['manifest-summary.viewMore']}
               </a>
             `
-          : nothing}
+          : html`
+              <a
+                id="view-more-disabled"
+                part=${ManifestSummary.cssParts.viewMore}
+                href=${this.viewMoreUrl}
+                target="_blank"
+              >
+                ${this.strings['manifest-summary.viewMore']}
+              </a>
+            `}
       </div>
     </div>`;
   }


### PR DESCRIPTION
## Changes in this pull request
Adds a disabled link state to the #view-more button when the URL is not present.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
