### PR TITLE
feat: Look for genAI information in more places

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-test:
     name: 'Build and test'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust toolchain

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-test:
     name: 'Build and test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust toolchain

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check-changeset:
     name: 'Check changeset status'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check-changeset:
     name: 'Check changeset status'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check-changeset:
     name: 'Check changeset status'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/common/changes/c2pa/mathern-other-sources_2025-04-08-17-41.json
+++ b/common/changes/c2pa/mathern-other-sources_2025-04-08-17-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "c2pa",
+      "comment": "feat: Lookup ai details in other parameters",
+      "type": "minor"
+    }
+  ],
+  "packageName": "c2pa"
+}

--- a/packages/c2pa/src/selectors/selectGenerativeInfo.ts
+++ b/packages/c2pa/src/selectors/selectGenerativeInfo.ts
@@ -81,7 +81,8 @@ export function selectGenerativeInfo(
         const { actions } = (assertion as C2paActionsAssertion).data;
         const genAiActions: GenerativeInfo[] = actions.reduce<GenerativeInfo[]>(
           (actionAcc, action: ActionV1) => {
-            const { digitalSourceType, softwareAgent } = action;
+            const { digitalSourceType, softwareAgent, parameters } = action;
+
             if (
               digitalSourceType &&
               genAiDigitalSourceTypes.includes(digitalSourceType)
@@ -92,6 +93,28 @@ export function selectGenerativeInfo(
                 type: formatGenAiDigitalSourceTypes(digitalSourceType),
                 softwareAgent: { name: softwareAgent },
               } as GenerativeInfo);
+            }
+
+            // for 3rd party models, we need to check the parameters
+            if (action.action === 'c2pa.opened' && parameters) {
+              const paramsDigitalSourceType =
+                parameters['com.adobe.digitalSourceType'];
+              const paramsSoftwareAgent = parameters['com.adobe.details'];
+              const provider = parameters['com.adobe.type'];
+
+              if (
+                paramsDigitalSourceType &&
+                provider === 'remoteProvider.3rdParty' &&
+                genAiDigitalSourceTypes.includes(paramsDigitalSourceType) &&
+                paramsSoftwareAgent
+              ) {
+                actionAcc.push({
+                  assertion,
+                  action: action,
+                  type: formatGenAiDigitalSourceTypes(paramsDigitalSourceType),
+                  softwareAgent: { name: paramsSoftwareAgent },
+                } as GenerativeInfo);
+              }
             }
 
             return actionAcc;

--- a/packages/c2pa/test/selectors/selectGenerativeInfo.spec.ts
+++ b/packages/c2pa/test/selectors/selectGenerativeInfo.spec.ts
@@ -122,6 +122,7 @@ describe('selectGenerativeInfo', function () {
         './node_modules/@contentauth/testing/fixtures/images/genai-actions-v2.jpg',
       );
       const manifest = result.manifestStore?.activeManifest;
+
       expect(manifest).not.toBeNull();
       if (manifest) {
         const genAssertions = selectGenerativeInfo(manifest);
@@ -138,6 +139,119 @@ describe('selectGenerativeInfo', function () {
             softwareAgent: { name: 'Adobe Firefly' },
           },
         ]);
+      }
+    });
+
+    it('should look up parameters details in assertion', async function (this: TestContext) {
+      const manifest = {
+        label: 'urn:uuid:05f3b244-301a-49c4-ae14-c24bec024002',
+        title: 'Generated Image',
+        format: 'image/png',
+        vendor: null,
+        claimGenerator: 'c2pa-js unit tests',
+        claimGeneratorHints: null,
+        claimGeneratorInfo: [],
+        instanceId: 'xmp:iid:12fe9a47-8ad3-4ad1-b362-2ff987428e03',
+        signatureInfo: {
+          alg: 'Ps256',
+          issuer: 'Unit tests',
+          cert_serial_number: '11111',
+          time: '2025-03-31T13:36:22+00:00',
+        },
+        credentials: [],
+        ingredients: [
+          {
+            title: 'An Image',
+            format: 'image/png',
+            documentId: null,
+            instanceId: 'xmp:iid:52cc660c-8de9-472e-9441-810749fc4514',
+            provenance: null,
+            hash: null,
+            isParent: true,
+            validationStatus: [],
+            metadata: null,
+            manifest: null,
+            thumbnail: {
+              blob: {},
+              contentType: 'image/jpeg',
+            },
+          },
+        ],
+        redactions: [],
+        parent: null,
+        thumbnail: null,
+        assertions: {
+          data: [
+            {
+              label: 'c2pa.actions',
+              data: {
+                actions: [
+                  {
+                    action: 'c2pa.opened',
+                    parameters: {
+                      'com.adobe.details': 'the-other-model-name',
+                      'com.adobe.digitalSourceType':
+                        'http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia',
+                      ingredient: {
+                        url: 'self#jumbf=c2pa.assertions/c2pa.ingredient',
+                        hash: [1, 2, 3],
+                      },
+                      'com.adobe.type': 'remoteProvider.3rdParty',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        verifiedIdentities: [],
+      };
+
+      expect(manifest).not.toBeNull();
+      if (manifest) {
+        const genAssertions = selectGenerativeInfo(manifest);
+        const expectedResult = [
+          {
+            assertion: {
+              label: 'c2pa.actions',
+              data: {
+                actions: [
+                  {
+                    action: 'c2pa.opened',
+                    parameters: {
+                      'com.adobe.details': 'the-other-model-name',
+                      'com.adobe.digitalSourceType':
+                        'http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia',
+                      ingredient: {
+                        url: 'self#jumbf=c2pa.assertions/c2pa.ingredient',
+                        hash: [1, 2, 3],
+                      },
+                      'com.adobe.type': 'remoteProvider.3rdParty',
+                    },
+                  },
+                ],
+              },
+            },
+            action: {
+              action: 'c2pa.opened',
+              parameters: {
+                'com.adobe.details': 'the-other-model-name',
+                'com.adobe.digitalSourceType':
+                  'http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia',
+                ingredient: {
+                  url: 'self#jumbf=c2pa.assertions/c2pa.ingredient',
+                  hash: [1, 2, 3],
+                },
+                'com.adobe.type': 'remoteProvider.3rdParty',
+              },
+            },
+            type: 'trainedAlgorithmicMedia',
+            softwareAgent: {
+              name: 'the-other-model-name',
+            },
+          },
+        ];
+        expect(genAssertions).toEqual(expectedResult);
       }
     });
   });

--- a/packages/c2pa/test/selectors/selectGenerativeInfo.spec.ts
+++ b/packages/c2pa/test/selectors/selectGenerativeInfo.spec.ts
@@ -145,7 +145,7 @@ describe('selectGenerativeInfo', function () {
     it('should look up parameters details in assertion', async function (this: TestContext) {
       const manifest = {
         label: 'urn:uuid:05f3b244-301a-49c4-ae14-c24bec024002',
-        title: 'Generated Image',
+        title: 'An image for tests',
         format: 'image/png',
         vendor: null,
         claimGenerator: 'c2pa-js unit tests',


### PR DESCRIPTION
## Changes in this pull request
Look for genAI information in more places:

Example manifest excerpt where we want to look:
```
"assertions": [
        {
          "label": "c2pa.actions",
          "data": {
            "actions": [
              {
                "action": "c2pa.opened",
                "parameters": {
                  "com.adobe.digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia",
                  "com.adobe.details": "name",
                  "ingredient": {
                   ...
                  },
                  "com.adobe.type": "remoteProvider.3rdParty"
                }
              }
            ]
          }
        }
      ]
```
Note `com.adobe.digitalSourceType` and `com.adobe.details`.

## Types of changes
Add support to look for genAI info in one more place.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment
