### PR TITLE
docs: Add instructions to install LLVM Clang.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,35 @@ This library aims to make viewing and verifying C2PA metadata in the browser as 
 
 For more information, please view the documentation at https://opensource.contentauthenticity.org/docs/js-sdk/getting-started/overview.
 
-## Getting started
+## Prerequisites
 
-This monorepo is managed by [Rush](https://rushjs.io/). To get started:
+To build this library on macOS, you must first install LLVM Clang as follows:
+1. If you haven't already, install Homebrew:
+  ```
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  ```
+1. Install LLVM Clang:
+  ```
+  brew install llvm
+  ```
+1. Add it to your PATH:
+  ```
+  export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+  ```
+  For future use, add it to your `.zshrc` file:
+  ```
+  echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> ~/.zshrc
+  ```
+
+Verify the installation:
+  ```
+  llvm-config --version
+  ```
+You should see a version number, such as 20.1.3.
+
+## Build
+
+This monorepo is managed by [Rush](https://rushjs.io/). To build the library:
 
 Install Rush:
 ```


### PR DESCRIPTION
Process from https://github.com/briansmith/ring/issues/1824. 

I had to do this to get `rush build` to work.
